### PR TITLE
Fix outdated comment about comments in WithSetupDDLs

### DIFF
--- a/options.go
+++ b/options.go
@@ -158,7 +158,6 @@ func WithClientConfig(config spanner.ClientConfig) Option {
 }
 
 // WithSetupDDLs sets DDLs to be executed.
-// Note: comments are not permitted.
 func WithSetupDDLs(ddls []string) Option {
 	return func(opts *emulatorOptions) error {
 		opts.setupDDLs = ddls


### PR DESCRIPTION
This pull request makes a minor documentation change to the `WithSetupDDLs` function in `options.go`. The note about comments not being permitted in DDLs has been removed from the function's docstring.

The both of real Spanner instance and cloud-spanner-emulator already accept comments in DDL.
- https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/releases/tag/v1.5.31