### PR TITLE
Add new API: Emulator, Env, Run*/Open*/Setup* functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,51 @@ func ExampleRunEmulatorWithClients() {
 }
 ```
 
-### Shared emulator with subtests (recommended for multi-database)
+### Recommended test setup
 
-spanemuboost supports more practical setup as recommended by [Cloud Spanner Emulator FAQ](https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/blob/master/README.md#what-is-the-recommended-test-setup)
+As recommended by [Cloud Spanner Emulator FAQ](https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/blob/master/README.md#what-is-the-recommended-test-setup):
 
 > What is the recommended test setup?
 > Use a single emulator process and create a Cloud Spanner instance within it. Since creating databases is cheap in the emulator, we recommend that each test bring up and tear down its own database. This ensures hermetic testing and allows the test suite to run tests in parallel if needed.
+
+Use `TestMain` to start a single emulator and share it across all test functions in the package. Each test function creates its own database via `SetupClients`.
+
+Note: `testing.M` does NOT implement `testing.TB`, so `Setup*` functions cannot be used in `TestMain` itself. Use `RunEmulator` to start the emulator, then `SetupClients` in each test function for per-test database setup with automatic cleanup.
+
+```go
+var emulator *spanemuboost.Emulator
+
+func TestMain(m *testing.M) {
+    var err error
+    emulator, err = spanemuboost.RunEmulator(context.Background(),
+        spanemuboost.EnableInstanceAutoConfigOnly(),
+    )
+    if err != nil { log.Fatal(err) }
+    code := m.Run()
+    emulator.Close()
+    os.Exit(code)
+}
+
+func TestCreate(t *testing.T) {
+    clients := spanemuboost.SetupClients(t, emulator,
+        spanemuboost.WithRandomDatabaseID(),
+        spanemuboost.WithSetupDDLs(ddls),
+    )
+    // use clients.Client...
+}
+
+func TestRead(t *testing.T) {
+    clients := spanemuboost.SetupClients(t, emulator,
+        spanemuboost.WithRandomDatabaseID(),
+        spanemuboost.WithSetupDDLs(ddls),
+    )
+    // use clients.Client...
+}
+```
+
+### Shared emulator with subtests
+
+When tests are naturally related and don't need `TestMain`, you can share an emulator within subtests of a single parent test.
 
 ```go
 func TestSuite(t *testing.T) {
@@ -132,34 +171,5 @@ func ExampleOpenClients() {
 
     fmt.Println(pks)
     // Output: [0 1 2 3 4 5 6 7 8 9]
-}
-```
-
-### TestMain pattern (shared emulator across test functions)
-
-Use `TestMain` when you want to share a single emulator across independently organized test functions (`TestCreate`, `TestRead`, etc.). This avoids starting a new emulator container per test function, which is significantly more resource-efficient.
-
-Note: `testing.M` does NOT implement `testing.TB`, so `Setup*` functions cannot be used in `TestMain` itself. Use `RunEmulator` to start the emulator, then `SetupClients` in each test function for per-test database setup with automatic cleanup.
-
-```go
-var emulator *spanemuboost.Emulator
-
-func TestMain(m *testing.M) {
-    var err error
-    emulator, err = spanemuboost.RunEmulator(context.Background(),
-        spanemuboost.EnableInstanceAutoConfigOnly(),
-    )
-    if err != nil { log.Fatal(err) }
-    code := m.Run()
-    emulator.Close()
-    os.Exit(code)
-}
-
-func TestFoo(t *testing.T) {
-    clients := spanemuboost.SetupClients(t, emulator,
-        spanemuboost.WithRandomDatabaseID(),
-        spanemuboost.WithSetupDDLs(ddls),
-    )
-    // ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ func TestMain(m *testing.M) {
     )
     if err != nil { log.Fatal(err) }
     code := m.Run()
-    emulator.Close()
+    if err := emulator.Close(); err != nil {
+        log.Printf("failed to close emulator: %v", err)
+    }
     os.Exit(code)
 }
 

--- a/README.md
+++ b/README.md
@@ -135,9 +135,11 @@ func ExampleOpenClients() {
 }
 ```
 
-### TestMain pattern (for legacy or cross-test-function sharing)
+### TestMain pattern (shared emulator across test functions)
 
-Note: `testing.M` does NOT implement `testing.TB`, so `Setup*` functions cannot be used in `TestMain`. Use the context-based `RunEmulator`/`OpenClients` API instead. The subtest pattern above is generally recommended over `TestMain`.
+Use `TestMain` when you want to share a single emulator across independently organized test functions (`TestCreate`, `TestRead`, etc.). This avoids starting a new emulator container per test function, which is significantly more resource-efficient.
+
+Note: `testing.M` does NOT implement `testing.TB`, so `Setup*` functions cannot be used in `TestMain` itself. Use `RunEmulator` to start the emulator, then `SetupClients` in each test function for per-test database setup with automatic cleanup.
 
 ```go
 var emulator *spanemuboost.Emulator

--- a/README.md
+++ b/README.md
@@ -14,26 +14,38 @@ Consider to use [memefish](https://github.com/cloudspannerecosystem/memefish) or
 
 ## Examples
 
-### Simple setup
+### Simple setup (test)
 
-[`spanemuboost.NewEmulatorWithClients()`](https://pkg.go.dev/github.com/apstndb/spanemuboost#NewEmulatorWithClients) can be used without required configurations.
+`spanemuboost.SetupEmulatorWithClients()` handles everything: starts the emulator, creates clients, and auto-cleans up when the test finishes.
 
 ```go
-func ExampleNewEmulatorWithClients() {
+func TestFoo(t *testing.T) {
+    env := spanemuboost.SetupEmulatorWithClients(t,
+        spanemuboost.WithSetupDDLs(ddls),
+    )
+    // env.Client, env.DatabaseClient, env.InstanceClient available
+    // cleanup is automatic via t.Cleanup
+}
+```
+
+### Simple setup (non-test)
+
+`spanemuboost.RunEmulatorWithClients()` can be used without required configurations.
+
+```go
+func ExampleRunEmulatorWithClients() {
     ctx := context.Background()
 
-    _, clients, teardown, err := spanemuboost.NewEmulatorWithClients(ctx)
+    env, err := spanemuboost.RunEmulatorWithClients(ctx)
     if err != nil {
         log.Fatalln(err)
         return
     }
 
-    defer teardown()
+    defer env.Close()
 
-    err = clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1")).Do(func(r *spanner.Row) error {
+    err = env.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1")).Do(func(r *spanner.Row) error {
         fmt.Println(r)
-        // Output: {fields: [type:{code:INT64}], values: [string_value:"1"]}
-		
         return nil
     })
     if err != nil {
@@ -42,7 +54,7 @@ func ExampleNewEmulatorWithClients() {
 }
 ```
 
-### Multiple databases setup
+### Shared emulator with subtests (recommended for multi-database)
 
 spanemuboost supports more practical setup as recommended by [Cloud Spanner Emulator FAQ](https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/blob/master/README.md#what-is-the-recommended-test-setup)
 
@@ -50,10 +62,34 @@ spanemuboost supports more practical setup as recommended by [Cloud Spanner Emul
 > Use a single emulator process and create a Cloud Spanner instance within it. Since creating databases is cheap in the emulator, we recommend that each test bring up and tear down its own database. This ensures hermetic testing and allows the test suite to run tests in parallel if needed.
 
 ```go
-func ExampleNewEmulatorAndNewClients() {
+func TestSuite(t *testing.T) {
+    emu := spanemuboost.SetupEmulator(t, spanemuboost.EnableInstanceAutoConfigOnly())
+
+    t.Run("test1", func(t *testing.T) {
+        clients := spanemuboost.SetupClients(t, emu,
+            spanemuboost.WithRandomDatabaseID(),
+            spanemuboost.WithSetupDDLs(ddls),
+        )
+        // use clients.Client...
+    })
+
+    t.Run("test2", func(t *testing.T) {
+        clients := spanemuboost.SetupClients(t, emu,
+            spanemuboost.WithRandomDatabaseID(),
+            spanemuboost.WithSetupDDLs(otherDDLs),
+        )
+        // use clients.Client...
+    })
+}
+```
+
+### Multiple databases (non-test)
+
+```go
+func ExampleOpenClients() {
     ctx := context.Background()
 
-    emulator, emulatorTeardown, err := spanemuboost.NewEmulator(ctx,
+    emu, err := spanemuboost.RunEmulator(ctx,
         spanemuboost.EnableInstanceAutoConfigOnly(),
     )
     if err != nil {
@@ -61,13 +97,12 @@ func ExampleNewEmulatorAndNewClients() {
         return
     }
 
-    defer emulatorTeardown()
+    defer emu.Close()
 
     var pks []int64
-    for i := 0; i < 10; i++ {
+    for i := range 10 {
         func() {
-            clients, clientsTeardown, err := spanemuboost.NewClients(ctx, emulator,
-                spanemuboost.EnableDatabaseAutoConfigOnly(),
+            clients, err := spanemuboost.OpenClients(ctx, emu,
                 spanemuboost.WithRandomDatabaseID(),
                 spanemuboost.WithSetupDDLs([]string{"CREATE TABLE tbl (PK INT64 PRIMARY KEY)"}),
                 spanemuboost.WithSetupDMLs([]spanner.Statement{
@@ -79,7 +114,7 @@ func ExampleNewEmulatorAndNewClients() {
                 return
             }
 
-            defer clientsTeardown()
+            defer clients.Close()
 
             err = clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT PK FROM tbl")).Do(func(r *spanner.Row) error {
                 var pk int64
@@ -97,5 +132,32 @@ func ExampleNewEmulatorAndNewClients() {
 
     fmt.Println(pks)
     // Output: [0 1 2 3 4 5 6 7 8 9]
+}
+```
+
+### TestMain pattern (for legacy or cross-test-function sharing)
+
+Note: `testing.M` does NOT implement `testing.TB`, so `Setup*` functions cannot be used in `TestMain`. Use the context-based `RunEmulator`/`OpenClients` API instead. The subtest pattern above is generally recommended over `TestMain`.
+
+```go
+var emulator *spanemuboost.Emulator
+
+func TestMain(m *testing.M) {
+    var err error
+    emulator, err = spanemuboost.RunEmulator(context.Background(),
+        spanemuboost.EnableInstanceAutoConfigOnly(),
+    )
+    if err != nil { log.Fatal(err) }
+    code := m.Run()
+    emulator.Close()
+    os.Exit(code)
+}
+
+func TestFoo(t *testing.T) {
+    clients := spanemuboost.SetupClients(t, emulator,
+        spanemuboost.WithRandomDatabaseID(),
+        spanemuboost.WithSetupDDLs(ddls),
+    )
+    // ...
 }
 ```

--- a/emulator.go
+++ b/emulator.go
@@ -1,0 +1,85 @@
+package spanemuboost
+
+import (
+	"context"
+	"errors"
+
+	tcspanner "github.com/testcontainers/testcontainers-go/modules/gcloud/spanner"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// Emulator wraps a Cloud Spanner Emulator container.
+// Use [RunEmulator] or [SetupEmulator] to create one.
+type Emulator struct {
+	container *tcspanner.Container
+	opts      *emulatorOptions
+}
+
+// URI returns the gRPC endpoint (host:port) of the emulator,
+// suitable for use as SPANNER_EMULATOR_HOST.
+func (e *Emulator) URI() string {
+	return e.container.URI()
+}
+
+// ClientOptions returns [option.ClientOption] values configured for connecting
+// to this emulator (endpoint, insecure credentials, no authentication).
+func (e *Emulator) ClientOptions() []option.ClientOption {
+	return []option.ClientOption{
+		option.WithEndpoint(e.container.URI()),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		option.WithoutAuthentication(),
+	}
+}
+
+// Close terminates the emulator container.
+func (e *Emulator) Close() error {
+	return e.container.Terminate(context.Background())
+}
+
+// Container returns the underlying [*tcspanner.Container] for direct access.
+// Most users should use [Emulator.URI] or [Emulator.ClientOptions] instead.
+func (e *Emulator) Container() *tcspanner.Container {
+	return e.container
+}
+
+// ProjectID returns the project ID configured for this emulator.
+func (e *Emulator) ProjectID() string { return e.opts.projectID }
+
+// InstanceID returns the instance ID configured for this emulator.
+func (e *Emulator) InstanceID() string { return e.opts.instanceID }
+
+// DatabaseID returns the database ID configured for this emulator.
+func (e *Emulator) DatabaseID() string { return e.opts.databaseID }
+
+// ProjectPath returns the project resource path.
+func (e *Emulator) ProjectPath() string { return projectPath(e.opts.projectID) }
+
+// InstancePath returns the instance resource path.
+func (e *Emulator) InstancePath() string { return instancePath(e.opts.projectID, e.opts.instanceID) }
+
+// DatabasePath returns the database resource path.
+func (e *Emulator) DatabasePath() string {
+	return databasePath(e.opts.projectID, e.opts.instanceID, e.opts.databaseID)
+}
+
+// Env combines an [Emulator] with [Clients] for the single-call use case.
+// Use [RunEmulatorWithClients] or [SetupEmulatorWithClients] to create one.
+type Env struct {
+	*Clients
+	emulator *Emulator
+}
+
+// Emulator returns the underlying [Emulator].
+func (e *Env) Emulator() *Emulator {
+	return e.emulator
+}
+
+// Close closes the clients and then terminates the emulator.
+func (e *Env) Close() error {
+	return errors.Join(
+		e.Clients.Close(),
+		e.emulator.Close(),
+	)
+}

--- a/example_test.go
+++ b/example_test.go
@@ -10,6 +10,77 @@ import (
 	"github.com/apstndb/spanemuboost"
 )
 
+func ExampleRunEmulatorWithClients() {
+	ctx := context.Background()
+
+	env, err := spanemuboost.RunEmulatorWithClients(ctx)
+	if err != nil {
+		log.Fatalln(err)
+		return
+	}
+
+	defer env.Close()
+
+	err = env.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1")).Do(func(r *spanner.Row) error {
+		fmt.Println(r)
+		return nil
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+	// Output: {fields: [type:{code:INT64}], values: [string_value:"1"]}
+}
+
+func ExampleOpenClients() {
+	ctx := context.Background()
+
+	emu, err := spanemuboost.RunEmulator(ctx,
+		spanemuboost.EnableInstanceAutoConfigOnly(),
+	)
+	if err != nil {
+		log.Fatalln(err)
+		return
+	}
+
+	defer emu.Close()
+
+	var pks []int64
+	for i := range 10 {
+		func() {
+			clients, err := spanemuboost.OpenClients(ctx, emu,
+				spanemuboost.WithRandomDatabaseID(),
+				spanemuboost.WithSetupDDLs([]string{"CREATE TABLE tbl (PK INT64 PRIMARY KEY)"}),
+				spanemuboost.WithSetupDMLs([]spanner.Statement{
+					{SQL: "INSERT INTO tbl(PK) VALUES(@i)", Params: map[string]any{"i": i}},
+				}),
+			)
+			if err != nil {
+				log.Fatalln(err)
+				return
+			}
+
+			defer clients.Close()
+
+			err = clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT PK FROM tbl")).Do(func(r *spanner.Row) error {
+				var pk int64
+				if err := r.ColumnByName("PK", &pk); err != nil {
+					return err
+				}
+				pks = append(pks, pk)
+				return nil
+			})
+			if err != nil {
+				log.Fatalln(err)
+			}
+		}()
+	}
+
+	fmt.Println(pks)
+	// Output: [0 1 2 3 4 5 6 7 8 9]
+}
+
+// Deprecated examples kept for backward compatibility testing.
+
 func ExampleNewEmulatorWithClients() {
 	ctx := context.Background()
 
@@ -45,7 +116,7 @@ func ExampleNewClients() {
 	defer emulatorTeardown()
 
 	var pks []int64
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		func() {
 			clients, clientsTeardown, err := spanemuboost.NewClients(ctx, emulator,
 				spanemuboost.EnableDatabaseAutoConfigOnly(),

--- a/internal.go
+++ b/internal.go
@@ -181,6 +181,37 @@ func createInstance(ctx context.Context, opts *emulatorOptions, clientOpts []opt
 	return nil
 }
 
+func newClientsFromEmulator(ctx context.Context, emu *Emulator, opts *emulatorOptions) (*Clients, error) {
+	clientOpts := emu.ClientOptions()
+
+	instanceCli, err := instance.NewInstanceAdminClient(ctx, clientOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	dbCli, err := database.NewDatabaseAdminClient(ctx, clientOpts...)
+	if err != nil {
+		instanceCli.Close()
+		return nil, err
+	}
+
+	client, err := spanner.NewClientWithConfig(ctx, opts.DatabasePath(), opts.clientConfig, slices.Concat(clientOpts, opts.clientOptionsForClient)...)
+	if err != nil {
+		dbCli.Close()
+		instanceCli.Close()
+		return nil, err
+	}
+
+	return &Clients{
+		InstanceClient: instanceCli,
+		DatabaseClient: dbCli,
+		Client:         client,
+		ProjectID:      opts.projectID,
+		InstanceID:     opts.instanceID,
+		DatabaseID:     opts.databaseID,
+	}, nil
+}
+
 func newClients(ctx context.Context, emulator *tcspanner.Container, opts *emulatorOptions) (clients *Clients, teardown func(), err error) {
 	clientOpts := defaultClientOpts(emulator)
 	instanceCli, err := instance.NewInstanceAdminClient(ctx, clientOpts...)

--- a/options.go
+++ b/options.go
@@ -67,9 +67,11 @@ func WithProjectID(projectID string) Option {
 }
 
 // WithRandomProjectID enables the random project ID. Default is disabled.
+// This clears any previously set project ID (including inherited values from [OpenClients]).
 func WithRandomProjectID() Option {
 	return func(opts *emulatorOptions) error {
 		opts.randomProjectID = true
+		opts.projectID = ""
 		return nil
 	}
 }
@@ -92,9 +94,11 @@ func WithInstanceID(instanceID string) Option {
 }
 
 // WithRandomInstanceID enables the random instance ID. Default is disabled.
+// This clears any previously set instance ID (including inherited values from [OpenClients]).
 func WithRandomInstanceID() Option {
 	return func(opts *emulatorOptions) error {
 		opts.randomInstanceID = true
+		opts.instanceID = ""
 		return nil
 	}
 }
@@ -117,9 +121,11 @@ func WithDatabaseID(databaseID string) Option {
 }
 
 // WithRandomDatabaseID enables the random database ID. Default is disabled.
+// This clears any previously set database ID (including inherited values from [OpenClients]).
 func WithRandomDatabaseID() Option {
 	return func(opts *emulatorOptions) error {
 		opts.randomDatabaseID = true
+		opts.databaseID = ""
 		return nil
 	}
 }
@@ -237,6 +243,18 @@ func (o *emulatorOptions) ProjectPath() string {
 	return projectPath(o.projectID)
 }
 
+// applyOptionsWithBase applies options starting from a pre-configured base.
+// Used by [OpenClients] to inherit emulator settings.
+func applyOptionsWithBase(base *emulatorOptions, options ...Option) (*emulatorOptions, error) {
+	opts := *base
+	for _, opt := range options {
+		if err := opt(&opts); err != nil {
+			return nil, err
+		}
+	}
+	return finalizeOptions(&opts)
+}
+
 func applyOptions(options ...Option) (*emulatorOptions, error) {
 	opts := &emulatorOptions{}
 
@@ -246,6 +264,10 @@ func applyOptions(options ...Option) (*emulatorOptions, error) {
 		}
 	}
 
+	return finalizeOptions(opts)
+}
+
+func finalizeOptions(opts *emulatorOptions) (*emulatorOptions, error) {
 	if opts.randomProjectID && opts.projectID != "" {
 		return nil, fmt.Errorf("WithRandomProjectID() and WithProjectID() are mutually exclusive")
 	}

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -2,6 +2,7 @@ package spanemuboost
 
 import (
 	"context"
+	"errors"
 
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
@@ -29,6 +30,94 @@ func (c *Clients) ProjectPath() string  { return projectPath(c.ProjectID) }
 func (c *Clients) InstancePath() string { return instancePath(c.ProjectID, c.InstanceID) }
 func (c *Clients) DatabasePath() string { return databasePath(c.ProjectID, c.InstanceID, c.DatabaseID) }
 
+// Close closes all Spanner clients.
+// [spanner.Client.Close] does not return an error, so only admin client errors are returned.
+func (c *Clients) Close() error {
+	c.Client.Close()
+	return errors.Join(
+		c.DatabaseClient.Close(),
+		c.InstanceClient.Close(),
+	)
+}
+
+// RunEmulator starts a Cloud Spanner Emulator container and performs any
+// configured bootstrap (instance/database creation, DDL, DML).
+// Call [Emulator.Close] to terminate the container when done.
+func RunEmulator(ctx context.Context, options ...Option) (*Emulator, error) {
+	opts, err := applyOptions(options...)
+	if err != nil {
+		return nil, err
+	}
+
+	container, _, err := newEmulator(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	emu := &Emulator{container: container, opts: opts}
+
+	if err = bootstrap(ctx, opts, emu.ClientOptions()...); err != nil {
+		emu.Close()
+		return nil, err
+	}
+
+	return emu, nil
+}
+
+// RunEmulatorWithClients starts a Cloud Spanner Emulator and opens Spanner clients.
+// Call [Env.Close] to close clients and terminate the container.
+func RunEmulatorWithClients(ctx context.Context, options ...Option) (*Env, error) {
+	opts, err := applyOptions(options...)
+	if err != nil {
+		return nil, err
+	}
+
+	container, _, err := newEmulator(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	emu := &Emulator{container: container, opts: opts}
+
+	if err = bootstrap(ctx, opts, emu.ClientOptions()...); err != nil {
+		emu.Close()
+		return nil, err
+	}
+
+	clients, err := newClientsFromEmulator(ctx, emu, opts)
+	if err != nil {
+		emu.Close()
+		return nil, err
+	}
+
+	return &Env{Clients: clients, emulator: emu}, nil
+}
+
+// OpenClients connects to an existing [Emulator] and opens Spanner clients.
+// Options inherit the emulator's projectID and instanceID; instance creation
+// is disabled by default (use [EnableAutoConfig] to override).
+// Call [Clients.Close] to close the clients when done.
+func OpenClients(ctx context.Context, emu *Emulator, options ...Option) (*Clients, error) {
+	base := &emulatorOptions{
+		projectID:             emu.opts.projectID,
+		instanceID:            emu.opts.instanceID,
+		disableCreateInstance: true,
+	}
+
+	opts, err := applyOptionsWithBase(base, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := bootstrap(ctx, opts, emu.ClientOptions()...); err != nil {
+		return nil, err
+	}
+
+	return newClientsFromEmulator(ctx, emu, opts)
+}
+
+// Deprecated: Use [RunEmulator] instead.
+//
 // NewEmulator initializes Cloud Spanner Emulator.
 // The emulator will be closed when teardown is called. You should call it.
 func NewEmulator(ctx context.Context, options ...Option) (emulator *tcspanner.Container, teardown func(), err error) {
@@ -50,6 +139,8 @@ func NewEmulator(ctx context.Context, options ...Option) (emulator *tcspanner.Co
 	return emulator, teardown, nil
 }
 
+// Deprecated: Use [RunEmulatorWithClients] instead.
+//
 // NewEmulatorWithClients initializes Cloud Spanner Emulator with Spanner clients.
 // The emulator and clients will be closed when teardown is called. You should call it.
 func NewEmulatorWithClients(ctx context.Context, options ...Option) (emulator *tcspanner.Container, clients *Clients, teardown func(), err error) {
@@ -80,6 +171,8 @@ func NewEmulatorWithClients(ctx context.Context, options ...Option) (emulator *t
 	}, nil
 }
 
+// Deprecated: Use [OpenClients] instead.
+//
 // NewClients setup existing Cloud Spanner Emulator with Spanner clients.
 // The clients will be closed when teardown is called. You should call it.
 func NewClients(ctx context.Context, emulator *tcspanner.Container, options ...Option) (clients *Clients, teardown func(), err error) {

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -76,6 +76,161 @@ func TestNewEmulatorWithClientsPostgreSQL(t *testing.T) {
 	}
 }
 
+func TestRunEmulatorWithClients(t *testing.T) {
+	type row struct {
+		PK  string `spanner:"pk"`
+		Col int64  `spanner:"col"`
+	}
+
+	env := SetupEmulatorWithClients(t,
+		WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX), col INT64) PRIMARY KEY (pk)"}),
+		WithSetupRawDMLs([]string{`INSERT INTO tbl (pk, col) VALUES ('foo', 1),('bar', 2)`}),
+	)
+
+	ctx := context.Background()
+	stmt := spanner.NewStatement(`SELECT pk, col FROM tbl ORDER BY pk`)
+	want := []*row{
+		{"bar", 2},
+		{"foo", 1},
+	}
+
+	var got []*row
+	err := spanner.SelectAll(env.Client.Single().Query(ctx, stmt), &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRunEmulatorWithClientsPostgreSQL(t *testing.T) {
+	type row struct {
+		PK  string `spanner:"pk"`
+		Col int64  `spanner:"col"`
+	}
+
+	env := SetupEmulatorWithClients(t,
+		WithSetupDDLs([]string{"CREATE TABLE tbl (pk text PRIMARY KEY, col bigint)"}),
+		WithSetupRawDMLs([]string{`INSERT INTO tbl (pk, col) VALUES ('foo', 1),('bar', 2)`}),
+		WithDatabaseDialect(databasepb.DatabaseDialect_POSTGRESQL),
+	)
+
+	ctx := context.Background()
+	stmt := spanner.NewStatement(`SELECT pk, col FROM tbl ORDER BY pk`)
+	want := []*row{
+		{"bar", 2},
+		{"foo", 1},
+	}
+
+	var got []*row
+	err := spanner.SelectAll(env.Client.Single().Query(ctx, stmt), &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSetupEmulatorAndSetupClients(t *testing.T) {
+	type row struct {
+		PK  string `spanner:"pk"`
+		Col int64  `spanner:"col"`
+	}
+
+	ddls := []string{"CREATE TABLE tbl (pk STRING(MAX), col INT64) PRIMARY KEY (pk)"}
+	dmls := []string{`INSERT INTO tbl (pk, col) VALUES ('foo', 1),('bar', 2)`}
+
+	emu := SetupEmulator(t, EnableInstanceAutoConfigOnly())
+
+	t.Run("default inherits instance skip", func(t *testing.T) {
+		clients := SetupClients(t, emu,
+			WithRandomDatabaseID(),
+			WithSetupDDLs(ddls),
+			WithSetupRawDMLs(dmls),
+		)
+
+		ctx := context.Background()
+		stmt := spanner.NewStatement(`SELECT pk, col FROM tbl ORDER BY pk`)
+		want := []*row{
+			{"bar", 2},
+			{"foo", 1},
+		}
+
+		var got []*row
+		err := spanner.SelectAll(clients.Client.Single().Query(ctx, stmt), &got)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("override with EnableAutoConfig", func(t *testing.T) {
+		clients := SetupClients(t, emu,
+			EnableAutoConfig(),
+			WithRandomInstanceID(),
+			WithRandomDatabaseID(),
+			WithSetupDDLs(ddls),
+			WithSetupRawDMLs(dmls),
+		)
+
+		ctx := context.Background()
+		stmt := spanner.NewStatement(`SELECT pk, col FROM tbl ORDER BY pk`)
+		want := []*row{
+			{"bar", 2},
+			{"foo", 1},
+		}
+
+		var got []*row
+		err := spanner.SelectAll(clients.Client.Single().Query(ctx, stmt), &got)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestEmulatorAccessors(t *testing.T) {
+	emu := SetupEmulator(t, DisableAutoConfig())
+
+	if got := emu.ProjectID(); got != DefaultProjectID {
+		t.Errorf("ProjectID() = %q, want %q", got, DefaultProjectID)
+	}
+	if got := emu.InstanceID(); got != DefaultInstanceID {
+		t.Errorf("InstanceID() = %q, want %q", got, DefaultInstanceID)
+	}
+	if got := emu.DatabaseID(); got != DefaultDatabaseID {
+		t.Errorf("DatabaseID() = %q, want %q", got, DefaultDatabaseID)
+	}
+	if got := emu.URI(); got == "" {
+		t.Error("URI() is empty")
+	}
+	if got := emu.Container(); got == nil {
+		t.Error("Container() is nil")
+	}
+	if got := emu.ProjectPath(); got != "projects/"+DefaultProjectID {
+		t.Errorf("ProjectPath() = %q", got)
+	}
+	if got := emu.InstancePath(); got != "projects/"+DefaultProjectID+"/instances/"+DefaultInstanceID {
+		t.Errorf("InstancePath() = %q", got)
+	}
+	if got := emu.DatabasePath(); got != "projects/"+DefaultProjectID+"/instances/"+DefaultInstanceID+"/databases/"+DefaultDatabaseID {
+		t.Errorf("DatabasePath() = %q", got)
+	}
+	if opts := emu.ClientOptions(); len(opts) != 3 {
+		t.Errorf("ClientOptions() returned %d options, want 3", len(opts))
+	}
+}
+
 func sliceOf[T any](values ...T) []T {
 	return values
 }

--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,66 @@
+package spanemuboost
+
+import (
+	"context"
+	"testing"
+)
+
+// SetupEmulator starts a Cloud Spanner Emulator and registers cleanup via [testing.TB.Cleanup].
+// It calls [testing.TB.Fatal] on setup error.
+// Use [RunEmulator] if you need a [context.Context] or are not in a test.
+func SetupEmulator(tb testing.TB, options ...Option) *Emulator {
+	tb.Helper()
+
+	emu, err := RunEmulator(context.Background(), options...)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	tb.Cleanup(func() {
+		if err := emu.Close(); err != nil {
+			tb.Errorf("spanemuboost: failed to close emulator: %v", err)
+		}
+	})
+
+	return emu
+}
+
+// SetupEmulatorWithClients starts a Cloud Spanner Emulator with clients and registers
+// cleanup via [testing.TB.Cleanup]. It calls [testing.TB.Fatal] on setup error.
+// Use [RunEmulatorWithClients] if you need a [context.Context] or are not in a test.
+func SetupEmulatorWithClients(tb testing.TB, options ...Option) *Env {
+	tb.Helper()
+
+	env, err := RunEmulatorWithClients(context.Background(), options...)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	tb.Cleanup(func() {
+		if err := env.Close(); err != nil {
+			tb.Errorf("spanemuboost: failed to close env: %v", err)
+		}
+	})
+
+	return env
+}
+
+// SetupClients opens Spanner clients against an existing [Emulator] and registers
+// cleanup via [testing.TB.Cleanup]. It calls [testing.TB.Fatal] on setup error.
+// Use [OpenClients] if you need a [context.Context] or are not in a test.
+func SetupClients(tb testing.TB, emu *Emulator, options ...Option) *Clients {
+	tb.Helper()
+
+	clients, err := OpenClients(context.Background(), emu, options...)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	tb.Cleanup(func() {
+		if err := clients.Close(); err != nil {
+			tb.Errorf("spanemuboost: failed to close clients: %v", err)
+		}
+	})
+
+	return clients
+}


### PR DESCRIPTION
## Summary

Adds a new API for v0.3.x that addresses several design issues in the current API:
- 4-value return from `NewEmulatorWithClients` → `*Env` with `Close() error`
- `teardown func()` swallows errors → `Close() error` throughout
- `*tcspanner.Container` leaks into public API → `*Emulator` wrapper with `Container()` escape hatch
- No `testing.TB` integration → `Setup*` functions with auto-cleanup
- Boilerplate in every test → single-call patterns

### New types

| Type | Purpose |
|------|---------|
| `Emulator` | Wraps emulator container. Provides `URI()`, `ClientOptions()`, `Close() error`, resource path accessors, `Container()` escape hatch |
| `Env` | Embeds `*Clients` + private `*Emulator`. Single-call use case (`env.Client.Single().Query(...)`) |
| `Clients.Close() error` | Closes all Spanner clients with proper error return via `errors.Join` |

### New functions

| Function | Description |
|----------|-------------|
| `RunEmulator` | Context-based, returns `(*Emulator, error)` |
| `RunEmulatorWithClients` | Context-based, returns `(*Env, error)` |
| `OpenClients` | Connects to existing `*Emulator`, inherits projectID/instanceID, disables instance creation by default |
| `SetupEmulator` | `testing.TB` integration, auto-cleanup |
| `SetupEmulatorWithClients` | `testing.TB` integration, auto-cleanup |
| `SetupClients` | `testing.TB` integration, auto-cleanup |

### OpenClients option inheritance

`OpenClients` starts from a fresh options base with:
- `projectID` and `instanceID` inherited from emulator
- `disableCreateInstance = true` (override with `EnableAutoConfig()`)
- Everything else at defaults

This means the common 2-phase pattern no longer requires `EnableDatabaseAutoConfigOnly()`.

### Deprecations

`NewEmulator`, `NewEmulatorWithClients`, `NewClients` are deprecated with `// Deprecated:` comments. They continue to work unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -v -count=1` — all tests pass (new + deprecated API)
- [x] New API tests: `TestRunEmulatorWithClients`, `TestRunEmulatorWithClientsPostgreSQL`, `TestSetupEmulatorAndSetupClients` (option inheritance + `EnableAutoConfig` override), `TestEmulatorAccessors`
- [x] Deprecated API tests unchanged and passing
- [x] New examples: `ExampleRunEmulatorWithClients`, `ExampleOpenClients`

🤖 Generated with [Claude Code](https://claude.com/claude-code)