### PR TITLE
Add WithStrictTeardown option for explicit resource cleanup

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -217,6 +217,8 @@ func newClientsFromEmulator(ctx context.Context, emu *Emulator, opts *emulatorOp
 		ProjectID:      opts.projectID,
 		InstanceID:     opts.instanceID,
 		DatabaseID:     opts.databaseID,
+		dropDatabase:   opts.strictTeardown && !opts.disableCreateDatabase,
+		dropInstance:   opts.strictTeardown && !opts.disableCreateInstance,
 	}, nil
 }
 

--- a/options.go
+++ b/options.go
@@ -20,6 +20,7 @@ type emulatorOptions struct {
 
 	disableCreateInstance bool
 	disableCreateDatabase bool
+	strictTeardown        bool
 
 	databaseDialect        databasepb.DatabaseDialect
 	setupDDLs              []string
@@ -227,6 +228,18 @@ func EnableDatabaseAutoConfigOnly() Option {
 	return func(opts *emulatorOptions) error {
 		opts.disableCreateInstance = true
 		opts.disableCreateDatabase = false
+		return nil
+	}
+}
+
+// WithStrictTeardown enables strict resource cleanup on [Clients.Close].
+// When enabled, [Clients.Close] drops any database or instance that was
+// auto-created during bootstrap before closing the Go clients.
+// This is useful when sequential tests reuse the same database ID with AutoConfig,
+// as it prevents "already exists" errors.
+func WithStrictTeardown() Option {
+	return func(opts *emulatorOptions) error {
+		opts.strictTeardown = true
 		return nil
 	}
 }

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -3,10 +3,13 @@ package spanemuboost
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
+	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
 	tcspanner "github.com/testcontainers/testcontainers-go/modules/gcloud/spanner"
 )
 
@@ -24,6 +27,9 @@ type Clients struct {
 	Client         *spanner.Client
 
 	ProjectID, InstanceID, DatabaseID string
+
+	dropDatabase bool
+	dropInstance bool
 }
 
 func (c *Clients) ProjectPath() string  { return projectPath(c.ProjectID) }
@@ -31,13 +37,34 @@ func (c *Clients) InstancePath() string { return instancePath(c.ProjectID, c.Ins
 func (c *Clients) DatabasePath() string { return databasePath(c.ProjectID, c.InstanceID, c.DatabaseID) }
 
 // Close closes all Spanner clients.
-// [spanner.Client.Close] does not return an error, so only admin client errors are returned.
+// If [WithStrictTeardown] was used, any auto-created database or instance is
+// dropped before the clients are closed.
+// [spanner.Client.Close] does not return an error, so only admin client and
+// resource cleanup errors are returned.
 func (c *Clients) Close() error {
 	c.Client.Close()
-	return errors.Join(
+
+	var dropErrs []error
+	ctx := context.Background()
+	if c.dropDatabase {
+		if err := c.DatabaseClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
+			Database: c.DatabasePath(),
+		}); err != nil {
+			dropErrs = append(dropErrs, fmt.Errorf("drop database %s: %w", c.DatabasePath(), err))
+		}
+	}
+	if c.dropInstance {
+		if err := c.InstanceClient.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{
+			Name: c.InstancePath(),
+		}); err != nil {
+			dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: %w", c.InstancePath(), err))
+		}
+	}
+
+	return errors.Join(append(dropErrs,
 		c.DatabaseClient.Close(),
 		c.InstanceClient.Close(),
-	)
+	)...)
 }
 
 // RunEmulator starts a Cloud Spanner Emulator container and performs any

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -46,18 +46,19 @@ func (c *Clients) Close() error {
 
 	var dropErrs []error
 	ctx := context.Background()
-	if c.dropDatabase {
-		if err := c.DatabaseClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
-			Database: c.DatabasePath(),
-		}); err != nil {
-			dropErrs = append(dropErrs, fmt.Errorf("drop database %s: %w", c.DatabasePath(), err))
-		}
-	}
 	if c.dropInstance {
+		// Deleting the instance also removes all databases within it,
+		// so there is no need to drop the database separately.
 		if err := c.InstanceClient.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{
 			Name: c.InstancePath(),
 		}); err != nil {
 			dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: %w", c.InstancePath(), err))
+		}
+	} else if c.dropDatabase {
+		if err := c.DatabaseClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
+			Database: c.DatabasePath(),
+		}); err != nil {
+			dropErrs = append(dropErrs, fmt.Errorf("drop database %s: %w", c.DatabasePath(), err))
 		}
 	}
 
@@ -116,6 +117,11 @@ func RunEmulatorWithClients(ctx context.Context, options ...Option) (*Env, error
 		_ = emu.Close()
 		return nil, err
 	}
+
+	// Env owns the emulator lifecycle — resources are cleaned up when the
+	// container terminates, so explicit drop on Clients.Close is unnecessary.
+	clients.dropDatabase = false
+	clients.dropInstance = false
 
 	return &Env{Clients: clients, emulator: emu}, nil
 }

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -2,6 +2,7 @@ package spanemuboost
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -197,6 +198,32 @@ func TestSetupEmulatorAndSetupClients(t *testing.T) {
 			t.Fatalf("mismatch (-want +got):\n%s", diff)
 		}
 	})
+}
+
+func TestWithStrictTeardown(t *testing.T) {
+	ddls := []string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}
+
+	emu := SetupEmulator(t, EnableInstanceAutoConfigOnly())
+
+	// Run two sequential subtests with the same database ID and AutoConfig.
+	// Without WithStrictTeardown, the second subtest would fail with "already exists".
+	for i := range 2 {
+		t.Run(fmt.Sprintf("iteration_%d", i), func(t *testing.T) {
+			clients := SetupClients(t, emu,
+				WithDatabaseID("strict-teardown-test"),
+				WithStrictTeardown(),
+				WithSetupDDLs(ddls),
+			)
+
+			ctx := context.Background()
+			iter := clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1"))
+			defer iter.Stop()
+			_, err := iter.Next()
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
 }
 
 func TestEmulatorAccessors(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `WithStrictTeardown()` option that enables explicit resource cleanup on `Clients.Close()`
- When enabled, `Clients.Close()` drops any auto-created database or instance before closing Go clients
- Add `TestWithStrictTeardown` that verifies sequential subtests can reuse the same database ID without "already exists" errors

## Motivation

By default, auto-created databases and instances persist until the emulator container is terminated. This is efficient for most use cases, but when sequential (non-parallel) tests reuse the same database ID with AutoConfig, the second test fails with "already exists". `WithStrictTeardown()` opts in to dropping resources on close, enabling this pattern.

## Test plan

- [x] `TestWithStrictTeardown` runs two sequential subtests with the same database ID — second iteration would fail without strict teardown
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)