### PR TITLE
Fix slow client creation by adding passthrough:/// and SkipDialSettingsValidation

### DIFF
--- a/emulator.go
+++ b/emulator.go
@@ -26,11 +26,25 @@ func (e *Emulator) URI() string {
 
 // ClientOptions returns [option.ClientOption] values configured for connecting
 // to this emulator (endpoint, insecure credentials, no authentication).
+//
+// The endpoint uses the passthrough:/// scheme to bypass gRPC name resolution
+// and avoid the slow authentication code path that would otherwise be triggered
+// when grpc.NewClient (dns resolver by default) is used by the auth layer.
+// This mirrors the approach used by the Spanner client library's
+// SPANNER_EMULATOR_HOST handling (googleapis/google-cloud-go#10947), as well as
+// the Bigtable and Datastore SDKs for their emulator paths.
+//
+// Currently the auth layer uses grpc.DialContext (passthrough by default), so
+// this is a defensive measure for the planned migration to grpc.NewClient.
 func (e *Emulator) ClientOptions() []option.ClientOption {
 	return []option.ClientOption{
+		// passthrough:/// tells gRPC to use the address as-is without DNS resolution.
 		option.WithEndpoint("passthrough:///" + e.container.URI()),
 		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		option.WithoutAuthentication(),
+		// SkipDialSettingsValidation is required because the passthrough:/// prefix
+		// fails the default endpoint validation. This is an internal option also used
+		// by the Spanner, Bigtable, and Datastore client libraries for emulator paths.
 		internaloption.SkipDialSettingsValidation(),
 	}
 }

--- a/emulator.go
+++ b/emulator.go
@@ -6,6 +6,7 @@ import (
 
 	tcspanner "github.com/testcontainers/testcontainers-go/modules/gcloud/spanner"
 	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -27,9 +28,10 @@ func (e *Emulator) URI() string {
 // to this emulator (endpoint, insecure credentials, no authentication).
 func (e *Emulator) ClientOptions() []option.ClientOption {
 	return []option.ClientOption{
-		option.WithEndpoint(e.container.URI()),
+		option.WithEndpoint("passthrough:///" + e.container.URI()),
 		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		option.WithoutAuthentication(),
+		internaloption.SkipDialSettingsValidation(),
 	}
 }
 

--- a/emulator.go
+++ b/emulator.go
@@ -6,9 +6,6 @@ import (
 
 	tcspanner "github.com/testcontainers/testcontainers-go/modules/gcloud/spanner"
 	"google.golang.org/api/option"
-	"google.golang.org/api/option/internaloption"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // Emulator wraps a Cloud Spanner Emulator container.
@@ -37,16 +34,7 @@ func (e *Emulator) URI() string {
 // Currently the auth layer uses grpc.DialContext (passthrough by default), so
 // this is a defensive measure for the planned migration to grpc.NewClient.
 func (e *Emulator) ClientOptions() []option.ClientOption {
-	return []option.ClientOption{
-		// passthrough:/// tells gRPC to use the address as-is without DNS resolution.
-		option.WithEndpoint("passthrough:///" + e.container.URI()),
-		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
-		option.WithoutAuthentication(),
-		// SkipDialSettingsValidation is required because the passthrough:/// prefix
-		// fails the default endpoint validation. This is an internal option also used
-		// by the Spanner, Bigtable, and Datastore client libraries for emulator paths.
-		internaloption.SkipDialSettingsValidation(),
-	}
+	return defaultClientOpts(e.container)
 }
 
 // Close terminates the emulator container.

--- a/internal.go
+++ b/internal.go
@@ -320,6 +320,8 @@ func newClients(ctx context.Context, emulator *tcspanner.Container, opts *emulat
 	}, teardown, nil
 }
 
+// defaultClientOpts returns client options for connecting to the emulator.
+// See [Emulator.ClientOptions] for details on passthrough:/// and SkipDialSettingsValidation.
 func defaultClientOpts(emulator *tcspanner.Container) []option.ClientOption {
 	return []option.ClientOption{
 		option.WithEndpoint("passthrough:///" + emulator.URI()),

--- a/internal.go
+++ b/internal.go
@@ -16,6 +16,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	tcspanner "github.com/testcontainers/testcontainers-go/modules/gcloud/spanner"
 	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -321,8 +322,9 @@ func newClients(ctx context.Context, emulator *tcspanner.Container, opts *emulat
 
 func defaultClientOpts(emulator *tcspanner.Container) []option.ClientOption {
 	return []option.ClientOption{
-		option.WithEndpoint(emulator.URI()),
+		option.WithEndpoint("passthrough:///" + emulator.URI()),
 		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		option.WithoutAuthentication(),
+		internaloption.SkipDialSettingsValidation(),
 	}
 }

--- a/internal.go
+++ b/internal.go
@@ -321,12 +321,18 @@ func newClients(ctx context.Context, emulator *tcspanner.Container, opts *emulat
 }
 
 // defaultClientOpts returns client options for connecting to the emulator.
-// See [Emulator.ClientOptions] for details on passthrough:/// and SkipDialSettingsValidation.
+// It is the shared implementation for [Emulator.ClientOptions] and the deprecated
+// newClients path. Once the deprecated path is removed, this function should be
+// inlined into [Emulator.ClientOptions].
 func defaultClientOpts(emulator *tcspanner.Container) []option.ClientOption {
 	return []option.ClientOption{
+		// passthrough:/// tells gRPC to use the address as-is without DNS resolution.
 		option.WithEndpoint("passthrough:///" + emulator.URI()),
 		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		option.WithoutAuthentication(),
+		// SkipDialSettingsValidation is required because the passthrough:/// prefix
+		// fails the default endpoint validation. This is an internal option also used
+		// by the Spanner, Bigtable, and Datastore client libraries for emulator paths.
 		internaloption.SkipDialSettingsValidation(),
 	}
 }

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -253,8 +253,8 @@ func TestEmulatorAccessors(t *testing.T) {
 	if got := emu.DatabasePath(); got != "projects/"+DefaultProjectID+"/instances/"+DefaultInstanceID+"/databases/"+DefaultDatabaseID {
 		t.Errorf("DatabasePath() = %q", got)
 	}
-	if opts := emu.ClientOptions(); len(opts) != 3 {
-		t.Errorf("ClientOptions() returned %d options, want 3", len(opts))
+	if opts := emu.ClientOptions(); len(opts) != 4 {
+		t.Errorf("ClientOptions() returned %d options, want 4", len(opts))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `passthrough:///` prefix to endpoint in `ClientOptions()` and `defaultClientOpts()` to bypass gRPC name resolution and the slow auth path
- Add `internaloption.SkipDialSettingsValidation()` (required because `passthrough:///` fails default endpoint validation)
- Add comments explaining the rationale and upstream references

## Background

The Spanner client library's `init()` hooks automatically apply `passthrough:///` and `SkipDialSettingsValidation` when `SPANNER_EMULATOR_HOST` is set (googleapis/google-cloud-go#10947). Since spanemuboost connects via `emu.URI()` without setting that env var, these options were missing.

Currently the auth layer uses `grpc.DialContext` (passthrough resolver by default), so the performance issue is **not actively triggered**. However, when the auth layer migrates to `grpc.NewClient` (dns resolver by default), spanemuboost users would silently regress with ~100x slower client creation. This is a defensive fix that aligns with the same pattern used by Spanner, Bigtable, and Datastore SDKs for their emulator paths.

See #7 for the full timeline and analysis.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -run TestEmulatorAccessors -v` (updated assertion from 3 to 4 options)
- [x] Full integration tests: `go test ./... -count=1`

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)