### PR TITLE
Disable native metrics by default for emulator connections

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -47,6 +47,11 @@ func newEmulator(ctx context.Context, opts *emulatorOptions) (container *tcspann
 	return container, teardown, nil
 }
 
+// executeDMLs creates a short-lived internal client solely for bootstrap DML
+// execution in the deprecated path. It uses a minimal config intentionally:
+// the user-provided ClientConfig is not applied here because this client is
+// discarded immediately after DMLs complete. In the new API path,
+// executeDMLsWithClient is used instead with the user-facing client.
 func executeDMLs(ctx context.Context, opts *emulatorOptions, clientOpts ...option.ClientOption) error {
 	client, err := spanner.NewClientWithConfig(ctx, opts.DatabasePath(),
 		spanner.ClientConfig{

--- a/internal.go
+++ b/internal.go
@@ -50,7 +50,8 @@ func newEmulator(ctx context.Context, opts *emulatorOptions) (container *tcspann
 func executeDMLs(ctx context.Context, opts *emulatorOptions, clientOpts ...option.ClientOption) error {
 	client, err := spanner.NewClientWithConfig(ctx, opts.DatabasePath(),
 		spanner.ClientConfig{
-			SessionPoolConfig: spanner.SessionPoolConfig{MinOpened: 1, MaxOpened: 1},
+			SessionPoolConfig:    spanner.SessionPoolConfig{MinOpened: 1, MaxOpened: 1},
+			DisableNativeMetrics: true,
 		},
 		clientOpts...)
 	if err != nil {

--- a/internal.go
+++ b/internal.go
@@ -244,7 +244,7 @@ func bootstrapAndCreateClients(ctx context.Context, emu *Emulator, opts *emulato
 
 	// Create the data client before DML execution so that the same client
 	// can be reused for both bootstrap DMLs and user operations.
-	client, err := spanner.NewClientWithConfig(ctx, opts.DatabasePath(), opts.clientConfig, slices.Concat(clientOpts, opts.clientOptionsForClient)...)
+	client, err := spanner.NewClientWithConfig(ctx, opts.DatabasePath(), *opts.clientConfig, slices.Concat(clientOpts, opts.clientOptionsForClient)...)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +300,7 @@ func newClients(ctx context.Context, emulator *tcspanner.Container, opts *emulat
 	}
 	teardown = dbCliTeardown
 
-	client, err := spanner.NewClientWithConfig(ctx, opts.DatabasePath(), opts.clientConfig, slices.Concat(clientOpts, opts.clientOptionsForClient)...)
+	client, err := spanner.NewClientWithConfig(ctx, opts.DatabasePath(), *opts.clientConfig, slices.Concat(clientOpts, opts.clientOptionsForClient)...)
 	if err != nil {
 		teardown()
 		return nil, nil, err

--- a/options.go
+++ b/options.go
@@ -25,8 +25,7 @@ type emulatorOptions struct {
 	databaseDialect        databasepb.DatabaseDialect
 	setupDDLs              []string
 	setupDMLs              []spanner.Statement
-	clientConfig           spanner.ClientConfig
-	clientConfigSet        bool
+	clientConfig           *spanner.ClientConfig // nil until finalizeOptions; guaranteed non-nil after
 	containerCustomizers   []testcontainers.ContainerCustomizer
 	clientOptionsForClient []option.ClientOption
 }
@@ -166,8 +165,7 @@ func WithEmulatorImage(image string) Option {
 // consider setting DisableNativeMetrics: true explicitly.
 func WithClientConfig(config spanner.ClientConfig) Option {
 	return func(opts *emulatorOptions) error {
-		opts.clientConfig = config
-		opts.clientConfigSet = true
+		opts.clientConfig = &config
 		return nil
 	}
 }
@@ -322,8 +320,8 @@ func finalizeOptions(opts *emulatorOptions) (*emulatorOptions, error) {
 	// Without SPANNER_EMULATOR_HOST, the Spanner client tries to create a real
 	// Cloud Monitoring exporter and contacts the GCP metadata server, adding
 	// unnecessary latency and errors. See #9.
-	if !opts.clientConfigSet {
-		opts.clientConfig.DisableNativeMetrics = true
+	if opts.clientConfig == nil {
+		opts.clientConfig = &spanner.ClientConfig{DisableNativeMetrics: true}
 	}
 
 	return opts, nil

--- a/options.go
+++ b/options.go
@@ -26,6 +26,7 @@ type emulatorOptions struct {
 	setupDDLs              []string
 	setupDMLs              []spanner.Statement
 	clientConfig           spanner.ClientConfig
+	clientConfigSet        bool
 	containerCustomizers   []testcontainers.ContainerCustomizer
 	clientOptionsForClient []option.ClientOption
 }
@@ -157,9 +158,16 @@ func WithEmulatorImage(image string) Option {
 }
 
 // WithClientConfig sets spanner.ClientConfig for NewClients and NewEmulatorWithClients.
+//
+// When this option is not used, spanemuboost sets DisableNativeMetrics to true
+// by default, since the Spanner native metrics infrastructure is unnecessary
+// for emulator connections and can add overhead (metadata server lookups,
+// monitoring exporter creation). If you provide a custom [spanner.ClientConfig],
+// consider setting DisableNativeMetrics: true explicitly.
 func WithClientConfig(config spanner.ClientConfig) Option {
 	return func(opts *emulatorOptions) error {
 		opts.clientConfig = config
+		opts.clientConfigSet = true
 		return nil
 	}
 }
@@ -309,6 +317,14 @@ func finalizeOptions(opts *emulatorOptions) (*emulatorOptions, error) {
 	opts.projectID = cmp.Or(opts.projectID, DefaultProjectID)
 	opts.instanceID = cmp.Or(opts.instanceID, DefaultInstanceID)
 	opts.databaseID = cmp.Or(opts.databaseID, DefaultDatabaseID)
+
+	// Disable native metrics by default for emulator connections.
+	// Without SPANNER_EMULATOR_HOST, the Spanner client tries to create a real
+	// Cloud Monitoring exporter and contacts the GCP metadata server, adding
+	// unnecessary latency and errors. See #9.
+	if !opts.clientConfigSet {
+		opts.clientConfig.DisableNativeMetrics = true
+	}
 
 	return opts, nil
 }


### PR DESCRIPTION
## Summary

- Disable Spanner native metrics by default for emulator connections to avoid unnecessary overhead
- Internal bootstrap client (`executeDMLs`) always sets `DisableNativeMetrics: true`
- Default `ClientConfig` (when `WithClientConfig` is not called) sets `DisableNativeMetrics: true`
- User-provided `ClientConfig` is not modified; godoc recommends `DisableNativeMetrics: true`

## Background

Without `SPANNER_EMULATOR_HOST` set, the Spanner client library creates a real Cloud Monitoring exporter and contacts the GCP metadata server (`detectClientLocation`). Since spanemuboost doesn't set that env var, this infrastructure activates unnecessarily, causing added latency and potential errors.

See #9 for the full analysis.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -run TestEmulatorAccessors -v`
- [x] Full integration tests: `go test ./... -count=1`

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)