### PR TITLE
Make WithRandom*ID() implicitly enable resource creation

### DIFF
--- a/options.go
+++ b/options.go
@@ -96,10 +96,15 @@ func WithInstanceID(instanceID string) Option {
 
 // WithRandomInstanceID enables the random instance ID. Default is disabled.
 // This clears any previously set instance ID (including inherited values from [OpenClients]).
+//
+// Because a random ID will never match an existing instance, this option also
+// enables instance auto-creation (sets disableCreateInstance to false).
+// To disable creation again, call [DisableAutoConfig] after this option.
 func WithRandomInstanceID() Option {
 	return func(opts *emulatorOptions) error {
 		opts.randomInstanceID = true
 		opts.instanceID = ""
+		opts.disableCreateInstance = false
 		return nil
 	}
 }
@@ -123,10 +128,15 @@ func WithDatabaseID(databaseID string) Option {
 
 // WithRandomDatabaseID enables the random database ID. Default is disabled.
 // This clears any previously set database ID (including inherited values from [OpenClients]).
+//
+// Because a random ID will never match an existing database, this option also
+// enables database auto-creation (sets disableCreateDatabase to false).
+// To disable creation again, call [DisableAutoConfig] after this option.
 func WithRandomDatabaseID() Option {
 	return func(opts *emulatorOptions) error {
 		opts.randomDatabaseID = true
 		opts.databaseID = ""
+		opts.disableCreateDatabase = false
 		return nil
 	}
 }

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -205,17 +205,16 @@ func TestWithRandomIDImpliesCreation(t *testing.T) {
 
 	emu := SetupEmulator(t, EnableInstanceAutoConfigOnly())
 
-	t.Run("random instance ID without creation fails", func(t *testing.T) {
+	t.Run("nonexistent instance without creation fails", func(t *testing.T) {
 		// OpenClients disables instance creation by default.
-		// A bare WithRandomInstanceID without implicit creation would fail here.
+		// Using a non-existent instance ID without creation should fail.
 		// On error OpenClients returns (nil, err), so no Close call is needed.
 		_, err := OpenClients(t.Context(), emu,
-			WithoutRandomInstanceID(),
-			WithRandomDatabaseID(),
+			WithInstanceID("nonexistent"),
 			WithSetupDDLs(ddls),
 		)
 		if err == nil {
-			t.Fatal("expected error for random instance ID without creation enabled, but got nil")
+			t.Fatal("expected error for nonexistent instance without creation enabled, but got nil")
 		}
 	})
 

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -200,6 +200,64 @@ func TestSetupEmulatorAndSetupClients(t *testing.T) {
 	})
 }
 
+func TestWithRandomIDImpliesCreation(t *testing.T) {
+	ddls := []string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}
+
+	// SetupEmulator with EnableInstanceAutoConfigOnly sets disableCreateInstance=false
+	// but the base for SetupClients sets disableCreateInstance=true.
+	// WithRandomInstanceID should implicitly re-enable instance creation,
+	// so this must succeed without an explicit EnableAutoConfig call.
+	emu := SetupEmulator(t, EnableInstanceAutoConfigOnly())
+
+	t.Run("random instance ID implies creation", func(t *testing.T) {
+		clients := SetupClients(t, emu,
+			WithRandomInstanceID(),
+			WithRandomDatabaseID(),
+			WithSetupDDLs(ddls),
+		)
+
+		ctx := context.Background()
+		iter := clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1"))
+		defer iter.Stop()
+		_, err := iter.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("random database ID implies creation", func(t *testing.T) {
+		clients := SetupClients(t, emu,
+			WithRandomDatabaseID(),
+			WithSetupDDLs(ddls),
+		)
+
+		ctx := context.Background()
+		iter := clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1"))
+		defer iter.Stop()
+		_, err := iter.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("DisableAutoConfig after random ID overrides", func(t *testing.T) {
+		// Use OpenClients instead of SetupClients because we need to inspect
+		// the returned error: SetupClients would call t.Fatal internally.
+		// WithRandomInstanceID enables creation, but DisableAutoConfig afterwards
+		// should re-disable it, verifying sequential override behavior.
+		// On error OpenClients returns (nil, err), so no Close call is needed.
+		_, err := OpenClients(context.Background(), emu,
+			WithRandomInstanceID(),
+			WithRandomDatabaseID(),
+			DisableAutoConfig(),
+			WithSetupDDLs(ddls),
+		)
+		if err == nil {
+			t.Fatal("expected error when DisableAutoConfig follows WithRandomInstanceID, but got nil")
+		}
+	})
+}
+
 func TestWithStrictTeardown(t *testing.T) {
 	ddls := []string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}
 

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -203,11 +203,21 @@ func TestSetupEmulatorAndSetupClients(t *testing.T) {
 func TestWithRandomIDImpliesCreation(t *testing.T) {
 	ddls := []string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}
 
-	// SetupEmulator with EnableInstanceAutoConfigOnly sets disableCreateInstance=false
-	// but the base for SetupClients sets disableCreateInstance=true.
-	// WithRandomInstanceID should implicitly re-enable instance creation,
-	// so this must succeed without an explicit EnableAutoConfig call.
 	emu := SetupEmulator(t, EnableInstanceAutoConfigOnly())
+
+	t.Run("random instance ID without creation fails", func(t *testing.T) {
+		// OpenClients disables instance creation by default.
+		// A bare WithRandomInstanceID without implicit creation would fail here.
+		// On error OpenClients returns (nil, err), so no Close call is needed.
+		_, err := OpenClients(t.Context(), emu,
+			WithoutRandomInstanceID(),
+			WithRandomDatabaseID(),
+			WithSetupDDLs(ddls),
+		)
+		if err == nil {
+			t.Fatal("expected error for random instance ID without creation enabled, but got nil")
+		}
+	})
 
 	t.Run("random instance ID implies creation", func(t *testing.T) {
 		clients := SetupClients(t, emu,
@@ -215,14 +225,7 @@ func TestWithRandomIDImpliesCreation(t *testing.T) {
 			WithRandomDatabaseID(),
 			WithSetupDDLs(ddls),
 		)
-
-		ctx := context.Background()
-		iter := clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1"))
-		defer iter.Stop()
-		_, err := iter.Next()
-		if err != nil {
-			t.Fatal(err)
-		}
+		mustConsumeQuery(t, clients, "SELECT 1")
 	})
 
 	t.Run("random database ID implies creation", func(t *testing.T) {
@@ -230,23 +233,12 @@ func TestWithRandomIDImpliesCreation(t *testing.T) {
 			WithRandomDatabaseID(),
 			WithSetupDDLs(ddls),
 		)
-
-		ctx := context.Background()
-		iter := clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1"))
-		defer iter.Stop()
-		_, err := iter.Next()
-		if err != nil {
-			t.Fatal(err)
-		}
+		mustConsumeQuery(t, clients, "SELECT 1")
 	})
 
 	t.Run("DisableAutoConfig after random ID overrides", func(t *testing.T) {
-		// Use OpenClients instead of SetupClients because we need to inspect
-		// the returned error: SetupClients would call t.Fatal internally.
-		// WithRandomInstanceID enables creation, but DisableAutoConfig afterwards
-		// should re-disable it, verifying sequential override behavior.
 		// On error OpenClients returns (nil, err), so no Close call is needed.
-		_, err := OpenClients(context.Background(), emu,
+		_, err := OpenClients(t.Context(), emu,
 			WithRandomInstanceID(),
 			WithRandomDatabaseID(),
 			DisableAutoConfig(),
@@ -272,14 +264,7 @@ func TestWithStrictTeardown(t *testing.T) {
 				WithStrictTeardown(),
 				WithSetupDDLs(ddls),
 			)
-
-			ctx := context.Background()
-			iter := clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1"))
-			defer iter.Stop()
-			_, err := iter.Next()
-			if err != nil {
-				t.Fatal(err)
-			}
+			mustConsumeQuery(t, clients, "SELECT 1")
 		})
 	}
 }
@@ -313,6 +298,16 @@ func TestEmulatorAccessors(t *testing.T) {
 	}
 	if opts := emu.ClientOptions(); len(opts) != 4 {
 		t.Errorf("ClientOptions() returned %d options, want 4", len(opts))
+	}
+}
+
+// mustConsumeQuery executes a query and fails the test if it returns an error.
+func mustConsumeQuery(t *testing.T, clients *Clients, sql string) {
+	t.Helper()
+	iter := clients.Client.Single().Query(t.Context(), spanner.NewStatement(sql))
+	defer iter.Stop()
+	if _, err := iter.Next(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -300,6 +300,10 @@ func TestEmulatorAccessors(t *testing.T) {
 	}
 }
 
+func sliceOf[T any](values ...T) []T {
+	return values
+}
+
 // mustConsumeQuery executes a query and fails the test if it returns an error.
 func mustConsumeQuery(t *testing.T, clients *Clients, sql string) {
 	t.Helper()
@@ -308,10 +312,6 @@ func mustConsumeQuery(t *testing.T, clients *Clients, sql string) {
 	if _, err := iter.Next(); err != nil {
 		t.Fatal(err)
 	}
-}
-
-func sliceOf[T any](values ...T) []T {
-	return values
 }
 
 func TestNewEmulatorAndNewClientsWithDisableAutoConfig(t *testing.T) {

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -218,6 +218,21 @@ func TestWithRandomIDImpliesCreation(t *testing.T) {
 		}
 	})
 
+	t.Run("nonexistent database without creation fails", func(t *testing.T) {
+		// OpenClients allows database creation by default, so explicitly disable it.
+		// DDLs are needed to trigger an operation against the nonexistent database;
+		// without DDLs, bootstrap skips the database step entirely.
+		// On error OpenClients returns (nil, err), so no Close call is needed.
+		_, err := OpenClients(t.Context(), emu,
+			DisableAutoConfig(),
+			WithDatabaseID("nonexistent"),
+			WithSetupDDLs(ddls),
+		)
+		if err == nil {
+			t.Fatal("expected error for nonexistent database without creation enabled, but got nil")
+		}
+	})
+
 	t.Run("random instance ID implies creation", func(t *testing.T) {
 		clients := SetupClients(t, emu,
 			WithRandomInstanceID(),

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -228,7 +228,10 @@ func TestWithRandomIDImpliesCreation(t *testing.T) {
 	})
 
 	t.Run("random database ID implies creation", func(t *testing.T) {
+		// DisableAutoConfig first so that WithRandomDatabaseID() must
+		// re-enable database creation to succeed.
 		clients := SetupClients(t, emu,
+			DisableAutoConfig(),
 			WithRandomDatabaseID(),
 			WithSetupDDLs(ddls),
 		)

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -311,8 +311,7 @@ func sliceOf[T any](values ...T) []T {
 func mustConsumeQuery(t *testing.T, clients *Clients, sql string) {
 	t.Helper()
 	iter := clients.Client.Single().Query(t.Context(), spanner.NewStatement(sql))
-	defer iter.Stop()
-	if _, err := iter.Next(); err != nil {
+	if err := iter.Do(func(*spanner.Row) error { return nil }); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary

- `WithRandomInstanceID()` now sets `disableCreateInstance = false` — a random ID will never match an existing instance, so creation is the only valid intent
- `WithRandomDatabaseID()` now sets `disableCreateDatabase = false` — same reasoning
- Options are applied sequentially, so a later `DisableAutoConfig()` can still re-disable creation
- `WithRandomProjectID()` is excluded: the emulator has no "create project" operation

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `make lint` passes
- [x] `TestWithRandomIDImpliesCreation` — new test with 3 subtests:
  - "random instance ID implies creation": `SetupClients` + `WithRandomInstanceID()` works without `EnableAutoConfig()`
  - "random database ID implies creation": `SetupClients` + `WithRandomDatabaseID()` works without `EnableAutoConfig()`
  - "DisableAutoConfig after random ID overrides": sequential override re-disables creation
- [x] Existing tests still pass (`go test ./... -count=1`)

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)