### PR TITLE
Use t.Context() instead of context.Background() in tests

### DIFF
--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -1,7 +1,6 @@
 package spanemuboost
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -16,7 +15,7 @@ func TestNewEmulatorWithClients(t *testing.T) {
 		Col int64  `spanner:"col"`
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, clients, teardown, err := NewEmulatorWithClients(ctx,
 		WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX), col INT64) PRIMARY KEY (pk)"}),
 		WithSetupRawDMLs([]string{`INSERT INTO tbl (pk, col) VALUES ('foo', 1),('bar', 2)`}),
@@ -49,7 +48,7 @@ func TestNewEmulatorWithClientsPostgreSQL(t *testing.T) {
 		Col int64  `spanner:"col"`
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, clients, teardown, err := NewEmulatorWithClients(ctx,
 		WithSetupDDLs([]string{"CREATE TABLE tbl (pk text PRIMARY KEY, col bigint)"}),
 		WithSetupRawDMLs([]string{`INSERT INTO tbl (pk, col) VALUES ('foo', 1),('bar', 2)`}),
@@ -88,7 +87,7 @@ func TestRunEmulatorWithClients(t *testing.T) {
 		WithSetupRawDMLs([]string{`INSERT INTO tbl (pk, col) VALUES ('foo', 1),('bar', 2)`}),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	stmt := spanner.NewStatement(`SELECT pk, col FROM tbl ORDER BY pk`)
 	want := []*row{
 		{"bar", 2},
@@ -118,7 +117,7 @@ func TestRunEmulatorWithClientsPostgreSQL(t *testing.T) {
 		WithDatabaseDialect(databasepb.DatabaseDialect_POSTGRESQL),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	stmt := spanner.NewStatement(`SELECT pk, col FROM tbl ORDER BY pk`)
 	want := []*row{
 		{"bar", 2},
@@ -154,7 +153,7 @@ func TestSetupEmulatorAndSetupClients(t *testing.T) {
 			WithSetupRawDMLs(dmls),
 		)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		stmt := spanner.NewStatement(`SELECT pk, col FROM tbl ORDER BY pk`)
 		want := []*row{
 			{"bar", 2},
@@ -181,7 +180,7 @@ func TestSetupEmulatorAndSetupClients(t *testing.T) {
 			WithSetupRawDMLs(dmls),
 		)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		stmt := spanner.NewStatement(`SELECT pk, col FROM tbl ORDER BY pk`)
 		want := []*row{
 			{"bar", 2},
@@ -215,7 +214,7 @@ func TestWithStrictTeardown(t *testing.T) {
 				WithSetupDDLs(ddls),
 			)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			iter := clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1"))
 			defer iter.Stop()
 			_, err := iter.Next()
@@ -268,7 +267,7 @@ func TestNewEmulatorAndNewClientsWithDisableAutoConfig(t *testing.T) {
 		Col int64  `spanner:"col"`
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Use the same DDLs and DMLs for all tests.
 	ddls := []string{"CREATE TABLE tbl (pk STRING(MAX), col INT64) PRIMARY KEY (pk)"}

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -336,8 +336,6 @@ func TestNewEmulatorAndNewClientsWithDisableAutoConfig(t *testing.T) {
 		Col int64  `spanner:"col"`
 	}
 
-	ctx := t.Context()
-
 	// Use the same DDLs and DMLs for all tests.
 	ddls := []string{"CREATE TABLE tbl (pk STRING(MAX), col INT64) PRIMARY KEY (pk)"}
 	dmls := []string{`INSERT INTO tbl (pk, col) VALUES ('foo', 1),('bar', 2)`}
@@ -390,6 +388,7 @@ func TestNewEmulatorAndNewClientsWithDisableAutoConfig(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			ctx := t.Context()
 			emulator, emuTeardown, err := NewEmulator(ctx, test.newEmulatorOpts...)
 			if err != nil {
 				t.Fatal(err)

--- a/testing.go
+++ b/testing.go
@@ -1,7 +1,6 @@
 package spanemuboost
 
 import (
-	"context"
 	"testing"
 )
 
@@ -12,7 +11,7 @@ import (
 func SetupEmulator(tb testing.TB, options ...Option) *Emulator {
 	tb.Helper()
 
-	emu, err := RunEmulator(context.Background(), options...)
+	emu, err := RunEmulator(tb.Context(), options...)
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -32,7 +31,7 @@ func SetupEmulator(tb testing.TB, options ...Option) *Emulator {
 func SetupEmulatorWithClients(tb testing.TB, options ...Option) *Env {
 	tb.Helper()
 
-	env, err := RunEmulatorWithClients(context.Background(), options...)
+	env, err := RunEmulatorWithClients(tb.Context(), options...)
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -52,7 +51,7 @@ func SetupEmulatorWithClients(tb testing.TB, options ...Option) *Env {
 func SetupClients(tb testing.TB, emu *Emulator, options ...Option) *Clients {
 	tb.Helper()
 
-	clients, err := OpenClients(context.Background(), emu, options...)
+	clients, err := OpenClients(tb.Context(), emu, options...)
 	if err != nil {
 		tb.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- Replace all `context.Background()` with `tb.Context()` / `t.Context()` in `testing.go` and `spanemuboost_test.go`
- Remove unused `"context"` imports from both files
- `example_test.go` is excluded as `Example*` functions don't receive a `*testing.T`

Go 1.24 added `testing.TB.Context()` which returns a context cancelled when the test completes, providing proper lifecycle management.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make lint`
- [x] Affected tests pass locally

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)