### PR TITLE
Enable schema teardown by default for fixed IDs

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -272,8 +272,8 @@ func bootstrapAndCreateClients(ctx context.Context, emu *Emulator, opts *emulato
 		ProjectID:      opts.projectID,
 		InstanceID:     opts.instanceID,
 		DatabaseID:     opts.databaseID,
-		dropDatabase:   opts.strictTeardown && !opts.disableCreateDatabase,
-		dropInstance:   opts.strictTeardown && !opts.disableCreateInstance,
+		dropDatabase:   opts.shouldDropDatabase(),
+		dropInstance:   opts.shouldDropInstance(),
 	}, nil
 }
 

--- a/options.go
+++ b/options.go
@@ -20,7 +20,7 @@ type emulatorOptions struct {
 
 	disableCreateInstance bool
 	disableCreateDatabase bool
-	strictTeardown        bool
+	schemaTeardown        *bool
 
 	databaseDialect        databasepb.DatabaseDialect
 	setupDDLs              []string
@@ -248,16 +248,59 @@ func EnableDatabaseAutoConfigOnly() Option {
 	}
 }
 
-// WithStrictTeardown enables strict resource cleanup on [Clients.Close].
-// When enabled, [Clients.Close] drops any database or instance that was
-// auto-created during bootstrap before closing the Go clients.
-// This is useful when sequential tests reuse the same database ID with AutoConfig,
-// as it prevents "already exists" errors.
-func WithStrictTeardown() Option {
+// ForceSchemaTeardown forces schema resource cleanup on [Clients.Close],
+// dropping any auto-created database or instance before closing the Go clients.
+//
+// By default, schema teardown is enabled for fixed IDs and disabled for random IDs.
+// This option overrides that default for all resources.
+func ForceSchemaTeardown() Option {
 	return func(opts *emulatorOptions) error {
-		opts.strictTeardown = true
+		opts.schemaTeardown = ptrOf(true)
 		return nil
 	}
+}
+
+// SkipSchemaTeardown disables schema resource cleanup on [Clients.Close].
+// Auto-created databases and instances will not be dropped on close.
+//
+// By default, schema teardown is enabled for fixed IDs;
+// use this option to opt out.
+func SkipSchemaTeardown() Option {
+	return func(opts *emulatorOptions) error {
+		opts.schemaTeardown = ptrOf(false)
+		return nil
+	}
+}
+
+// Deprecated: Use [ForceSchemaTeardown] instead.
+func WithStrictTeardown() Option {
+	return ForceSchemaTeardown()
+}
+
+// shouldDropInstance returns whether the instance should be dropped on Close.
+// If schemaTeardown is explicitly set, it takes precedence.
+// Otherwise, a non-random (fixed) instance ID implies teardown.
+func (o *emulatorOptions) shouldDropInstance() bool {
+	if o.disableCreateInstance {
+		return false
+	}
+	if o.schemaTeardown != nil {
+		return *o.schemaTeardown
+	}
+	return !o.randomInstanceID
+}
+
+// shouldDropDatabase returns whether the database should be dropped on Close.
+// If schemaTeardown is explicitly set, it takes precedence.
+// Otherwise, a non-random (fixed) database ID implies teardown.
+func (o *emulatorOptions) shouldDropDatabase() bool {
+	if o.disableCreateDatabase {
+		return false
+	}
+	if o.schemaTeardown != nil {
+		return *o.schemaTeardown
+	}
+	return !o.randomDatabaseID
 }
 
 func (o *emulatorOptions) DatabasePath() string {
@@ -342,6 +385,8 @@ const (
 	databaseIDChars      = databaseIDFirstChars + "0123456789"
 	idRange              = 30
 )
+
+func ptrOf[T any](v T) *T { return &v }
 
 // generateRandomID generates a random database ID.
 // Generated ID will be this format: [a-z][a-z0-9]{29}

--- a/options.go
+++ b/options.go
@@ -278,29 +278,26 @@ func WithStrictTeardown() Option {
 }
 
 // shouldDropInstance returns whether the instance should be dropped on Close.
-// If schemaTeardown is explicitly set, it takes precedence.
-// Otherwise, a non-random (fixed) instance ID implies teardown.
 func (o *emulatorOptions) shouldDropInstance() bool {
-	if o.disableCreateInstance {
-		return false
-	}
-	if o.schemaTeardown != nil {
-		return *o.schemaTeardown
-	}
-	return !o.randomInstanceID
+	return o.shouldDropResource(o.disableCreateInstance, o.randomInstanceID)
 }
 
 // shouldDropDatabase returns whether the database should be dropped on Close.
-// If schemaTeardown is explicitly set, it takes precedence.
-// Otherwise, a non-random (fixed) database ID implies teardown.
 func (o *emulatorOptions) shouldDropDatabase() bool {
-	if o.disableCreateDatabase {
+	return o.shouldDropResource(o.disableCreateDatabase, o.randomDatabaseID)
+}
+
+// shouldDropResource returns whether a resource should be dropped on Close.
+// If schemaTeardown is explicitly set, it takes precedence.
+// Otherwise, a non-random (fixed) ID implies teardown.
+func (o *emulatorOptions) shouldDropResource(disableCreate, isRandomID bool) bool {
+	if disableCreate {
 		return false
 	}
 	if o.schemaTeardown != nil {
 		return *o.schemaTeardown
 	}
-	return !o.randomDatabaseID
+	return !isRandomID
 }
 
 func (o *emulatorOptions) DatabasePath() string {

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -20,7 +20,16 @@ const (
 	DefaultDatabaseID    = "emulator-database"
 )
 
-// Clients struct is container of Spanner clients.
+// Clients holds Spanner clients and manages the lifecycle of schema resources
+// (instances and databases) auto-created during bootstrap.
+//
+// By default, auto-created resources with fixed IDs are dropped on [Clients.Close],
+// while resources with random IDs are not (since they never collide).
+// Use [ForceSchemaTeardown] or [SkipSchemaTeardown] to override.
+//
+// For [RunEmulatorWithClients]/[SetupEmulatorWithClients], teardown is disabled
+// because the emulator container owns the resource lifecycle;
+// use [ForceSchemaTeardown] to override.
 type Clients struct {
 	InstanceClient *instance.InstanceAdminClient
 	DatabaseClient *database.DatabaseAdminClient
@@ -37,8 +46,8 @@ func (c *Clients) InstancePath() string { return instancePath(c.ProjectID, c.Ins
 func (c *Clients) DatabasePath() string { return databasePath(c.ProjectID, c.InstanceID, c.DatabaseID) }
 
 // Close closes all Spanner clients.
-// If [WithStrictTeardown] was used, any auto-created database or instance is
-// dropped before the clients are closed.
+// By default, auto-created resources with fixed IDs are dropped before
+// the clients are closed. See [ForceSchemaTeardown] and [SkipSchemaTeardown].
 // [spanner.Client.Close] does not return an error, so only admin client and
 // resource cleanup errors are returned.
 func (c *Clients) Close() error {
@@ -117,9 +126,11 @@ func RunEmulatorWithClients(ctx context.Context, options ...Option) (*Env, error
 	}
 
 	// Env owns the emulator lifecycle — resources are cleaned up when the
-	// container terminates, so explicit drop on Clients.Close is unnecessary.
-	clients.dropDatabase = false
-	clients.dropInstance = false
+	// container terminates, so disable schema teardown unless explicitly forced.
+	if opts.schemaTeardown == nil || !*opts.schemaTeardown {
+		clients.dropDatabase = false
+		clients.dropInstance = false
+	}
 
 	return &Env{Clients: clients, emulator: emu}, nil
 }

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -127,7 +127,8 @@ func RunEmulatorWithClients(ctx context.Context, options ...Option) (*Env, error
 
 	// Env owns the emulator lifecycle — resources are cleaned up when the
 	// container terminates, so disable schema teardown unless explicitly forced.
-	if opts.schemaTeardown == nil || !*opts.schemaTeardown {
+	forceTeardown := opts.schemaTeardown != nil && *opts.schemaTeardown
+	if !forceTeardown {
 		clients.dropDatabase = false
 		clients.dropInstance = false
 	}

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -2,7 +2,6 @@ package spanemuboost
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -267,23 +266,64 @@ func TestWithRandomIDImpliesCreation(t *testing.T) {
 	})
 }
 
-func TestWithStrictTeardown(t *testing.T) {
+func TestSchemaTeardown(t *testing.T) {
 	ddls := []string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}
 
 	emu := SetupEmulator(t, EnableInstanceAutoConfigOnly())
 
-	// Run two sequential subtests with the same database ID and AutoConfig.
-	// Without WithStrictTeardown, the second subtest would fail with "already exists".
-	for i := range 2 {
-		t.Run(fmt.Sprintf("iteration_%d", i), func(t *testing.T) {
+	t.Run("fixed ID is dropped by default", func(t *testing.T) {
+		// Create database in a subtest so it is closed (and torn down) on exit.
+		t.Run("create", func(t *testing.T) {
 			clients := SetupClients(t, emu,
-				WithDatabaseID("strict-teardown-test"),
-				WithStrictTeardown(),
+				WithDatabaseID("fixed-teardown"),
 				WithSetupDDLs(ddls),
 			)
 			mustConsumeQuery(t, clients, "SELECT 1")
 		})
-	}
+		// If teardown worked, re-creating with the same ID should succeed.
+		t.Run("recreate", func(t *testing.T) {
+			clients := SetupClients(t, emu,
+				WithDatabaseID("fixed-teardown"),
+				WithSetupDDLs(ddls),
+			)
+			mustConsumeQuery(t, clients, "SELECT 1")
+		})
+	})
+
+	t.Run("SkipSchemaTeardown keeps database", func(t *testing.T) {
+		// Create database with teardown skipped in a subtest.
+		t.Run("create", func(t *testing.T) {
+			clients := SetupClients(t, emu,
+				WithDatabaseID("skip-teardown"),
+				SkipSchemaTeardown(),
+				WithSetupDDLs(ddls),
+			)
+			mustConsumeQuery(t, clients, "SELECT 1")
+		})
+		// Database still exists, so re-creating should fail.
+		// On error OpenClients returns (nil, err), so no Close call is needed.
+		_, err := OpenClients(t.Context(), emu,
+			WithDatabaseID("skip-teardown"),
+			WithSetupDDLs(ddls),
+		)
+		if err == nil {
+			t.Fatal("expected 'already exists' error, but got nil")
+		}
+	})
+
+	t.Run("random ID is not dropped by default", func(t *testing.T) {
+		// Random IDs never collide, so teardown is unnecessary.
+		// Verify that dropDatabase is false by default for random IDs.
+		t.Run("create", func(t *testing.T) {
+			clients := SetupClients(t, emu,
+				WithRandomDatabaseID(),
+				WithSetupDDLs(ddls),
+			)
+			mustConsumeQuery(t, clients, "SELECT 1")
+		})
+		// This just verifies random IDs work without teardown overhead.
+		// No "already exists" check since the ID is random.
+	})
 }
 
 func TestEmulatorAccessors(t *testing.T) {

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -311,17 +311,30 @@ func TestSchemaTeardown(t *testing.T) {
 	})
 
 	t.Run("random ID is not dropped by default", func(t *testing.T) {
-		// Random IDs never collide, so teardown is unnecessary.
-		// Verify that dropDatabase is false by default for random IDs.
+		// Random IDs are not dropped by default. Verify by creating a
+		// database with a random ID, closing the clients, and then
+		// successfully reconnecting to it.
+		var dbID string
 		t.Run("create", func(t *testing.T) {
 			clients := SetupClients(t, emu,
 				WithRandomDatabaseID(),
 				WithSetupDDLs(ddls),
 			)
+			dbID = clients.DatabaseID
 			mustConsumeQuery(t, clients, "SELECT 1")
 		})
-		// This just verifies random IDs work without teardown overhead.
-		// No "already exists" check since the ID is random.
+		// After "create" subtest, clients are closed. The database should
+		// still exist. Reconnect with auto-creation disabled to confirm.
+		reconnectClients, err := OpenClients(t.Context(), emu,
+			WithDatabaseID(dbID),
+			DisableAutoConfig(),
+		)
+		if err != nil {
+			t.Fatalf("expected to reconnect to existing random-ID database, but got error: %v", err)
+		}
+		if err := reconnectClients.Close(); err != nil {
+			t.Errorf("failed to close reconnect clients: %v", err)
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary

- Auto-created resources with **fixed IDs** are now dropped on `Clients.Close` by default
- Resources with **random IDs** are not dropped (they never collide)
- Decision is per-resource: `dropInstance` depends on `randomInstanceID`, `dropDatabase` depends on `randomDatabaseID`
- `RunEmulatorWithClients`/`SetupEmulatorWithClients` remain teardown-disabled unless `ForceSchemaTeardown()` is explicitly set

## New options

| Option | Purpose |
|---|---|
| `ForceSchemaTeardown()` | Override default: force drop on close (e.g. for random IDs or emulator-with-clients) |
| `SkipSchemaTeardown()` | Override default: skip drop on close (e.g. for fixed IDs sharing a database across tests) |

`WithStrictTeardown()` is deprecated in favor of `ForceSchemaTeardown()`.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `make lint`
- [x] `TestSchemaTeardown/fixed_ID_is_dropped_by_default` — fixed ID re-creation succeeds after subtest close
- [x] `TestSchemaTeardown/SkipSchemaTeardown_keeps_database` — skipped teardown causes "already exists"
- [x] `TestSchemaTeardown/random_ID_is_not_dropped_by_default` — random ID works without teardown
- [x] Existing tests pass

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)