### PR TITLE
Use context.Background() in deprecated newEmulator teardown

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -39,7 +39,7 @@ func newEmulator(ctx context.Context, opts *emulatorOptions) (container *tcspann
 	}
 
 	teardown = func() {
-		if err := container.Terminate(context.WithoutCancel(ctx)); err != nil {
+		if err := container.Terminate(context.Background()); err != nil {
 			log.Printf("failed to terminate Cloud Spanner Emulator: %v", err)
 		}
 	}


### PR DESCRIPTION
## Summary

- Unify cleanup context usage: replace `context.WithoutCancel(ctx)` with `context.Background()` in the deprecated `newEmulator` teardown to match `Emulator.Close()`

Closes #18

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)