### PR TITLE
Document t.Parallel() support and t.Setenv pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,14 @@ func TestRead(t *testing.T) {
 
 ### Shared emulator with subtests
 
-When tests are naturally related and don't need `TestMain`, you can share an emulator within subtests of a single parent test.
+When tests are naturally related and don't need `TestMain`, you can share an emulator within subtests of a single parent test. Since each subtest creates its own database via `WithRandomDatabaseID()`, subtests can safely run in parallel with `t.Parallel()`.
 
 ```go
 func TestSuite(t *testing.T) {
     emu := spanemuboost.SetupEmulator(t, spanemuboost.EnableInstanceAutoConfigOnly())
 
     t.Run("test1", func(t *testing.T) {
+        t.Parallel()
         clients := spanemuboost.SetupClients(t, emu,
             spanemuboost.WithRandomDatabaseID(),
             spanemuboost.WithSetupDDLs(ddls),
@@ -115,6 +116,7 @@ func TestSuite(t *testing.T) {
     })
 
     t.Run("test2", func(t *testing.T) {
+        t.Parallel()
         clients := spanemuboost.SetupClients(t, emu,
             spanemuboost.WithRandomDatabaseID(),
             spanemuboost.WithSetupDDLs(otherDDLs),
@@ -123,6 +125,23 @@ func TestSuite(t *testing.T) {
     })
 }
 ```
+
+### Using `SPANNER_EMULATOR_HOST` environment variable
+
+For serial tests with code that reads `SPANNER_EMULATOR_HOST` directly instead of accepting a client, you can use `t.Setenv` to set the environment variable:
+
+```go
+func TestWithEnvVar(t *testing.T) {
+    emu := spanemuboost.SetupEmulator(t, spanemuboost.EnableInstanceAutoConfigOnly())
+    t.Setenv("SPANNER_EMULATOR_HOST", emu.URI())
+    // Code under test that reads SPANNER_EMULATOR_HOST directly
+}
+```
+
+**Caveats:**
+- `t.Setenv` cannot be used with `t.Parallel()` or tests with parallel ancestors (it panics).
+- The environment variable is process-global and doesn't scale to concurrent tests.
+- Prefer passing `emu.ClientOptions()` or clients directly when possible.
 
 ### Multiple databases (non-test)
 

--- a/emulator.go
+++ b/emulator.go
@@ -17,6 +17,13 @@ type Emulator struct {
 
 // URI returns the gRPC endpoint (host:port) of the emulator,
 // suitable for use as SPANNER_EMULATOR_HOST.
+//
+// In serial tests, you can use [testing.T.Setenv] to set the environment variable:
+//
+//	t.Setenv("SPANNER_EMULATOR_HOST", emu.URI())
+//
+// Note that [testing.T.Setenv] panics if the test or an ancestor has called [testing.T.Parallel].
+// Prefer [Emulator.ClientOptions] when possible.
 func (e *Emulator) URI() string {
 	return e.container.URI()
 }


### PR DESCRIPTION
## Summary

- Add `t.Parallel()` to the "Shared emulator with subtests" README example to show that `WithRandomDatabaseID()` naturally supports parallel subtests
- Add new "Using `SPANNER_EMULATOR_HOST` environment variable" README section documenting the `t.Setenv` pattern with caveats
- Update `Emulator.URI()` godoc to mention the `t.Setenv` usage pattern

Closes #17
Closes #20

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `make lint` passes
- [x] README examples are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)