### PR TITLE
Add LazyEmulator for deferred emulator initialization

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.23.2'
+          go-version: '1.24'
 
       - name: Build
         run: go build -v ./...
 
       - name: Test
-        run: go test -v ./...
+        run: go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ Consider to use [memefish](https://github.com/cloudspannerecosystem/memefish) or
 
 ## Examples
 
-### Simple setup (test)
-
-`spanemuboost.SetupEmulatorWithClients()` handles everything: starts the emulator, creates clients, and auto-cleans up when the test finishes.
+### Quick start
 
 ```go
 func TestFoo(t *testing.T) {
@@ -28,42 +26,50 @@ func TestFoo(t *testing.T) {
 }
 ```
 
-### Simple setup (non-test)
+For non-test usage (e.g. embedding the emulator in an application where the `testing` package is unavailable), see runnable examples on [pkg.go.dev](https://pkg.go.dev/github.com/apstndb/spanemuboost#pkg-examples).
 
-`spanemuboost.RunEmulatorWithClients()` can be used without required configurations.
+### Shared emulator patterns
 
-```go
-func ExampleRunEmulatorWithClients() {
-    ctx := context.Background()
-
-    env, err := spanemuboost.RunEmulatorWithClients(ctx)
-    if err != nil {
-        log.Fatalln(err)
-        return
-    }
-
-    defer env.Close()
-
-    err = env.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1")).Do(func(r *spanner.Row) error {
-        fmt.Println(r)
-        return nil
-    })
-    if err != nil {
-        log.Fatalln(err)
-    }
-}
-```
-
-### Recommended test setup
-
-As recommended by [Cloud Spanner Emulator FAQ](https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/blob/master/README.md#what-is-the-recommended-test-setup):
+As [recommended by the Cloud Spanner Emulator FAQ](https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/blob/master/README.md#what-is-the-recommended-test-setup):
 
 > What is the recommended test setup?
 > Use a single emulator process and create a Cloud Spanner instance within it. Since creating databases is cheap in the emulator, we recommend that each test bring up and tear down its own database. This ensures hermetic testing and allows the test suite to run tests in parallel if needed.
 
-Use `TestMain` to start a single emulator and share it across all test functions in the package. Each test function creates its own database via `SetupClients`.
+| Pattern | Emulator lifetime | Best for |
+|---|---|---|
+| **Lazy** (`NewLazyEmulator` + `SetupClients`) | First `SetupClients` call &rarr; `TestMain` cleanup | Packages mixing emulator and non-emulator tests; skips startup when unused |
+| **Eager** (`RunEmulator` + `SetupClients`) | `TestMain` start &rarr; `TestMain` cleanup | All tests need the emulator; fail fast on startup errors |
+| **Subtests** (`SetupEmulator` + `SetupClients`) | Parent test &rarr; `t.Cleanup` | Related tests grouped under one function; supports `t.Parallel()` in subtests |
 
-Note: `testing.M` does NOT implement `testing.TB`, so `Setup*` functions cannot be used in `TestMain` itself. Use `RunEmulator` to start the emulator, then `SetupClients` in each test function for per-test database setup with automatic cleanup.
+#### Lazy shared emulator (recommended)
+
+The emulator starts only when the first test calls `SetupClients` with the `LazyEmulator`. If `go test -run TestUnit` matches only tests that never use it, the container is never started.
+
+```go
+var lazyEmu = spanemuboost.NewLazyEmulator(spanemuboost.EnableInstanceAutoConfigOnly())
+
+func TestMain(m *testing.M) {
+    code := m.Run()
+    lazyEmu.Close() // no-op if no test used the emulator
+    os.Exit(code)
+}
+
+func TestCreate(t *testing.T) {
+    clients := spanemuboost.SetupClients(t, lazyEmu,
+        spanemuboost.WithRandomDatabaseID(),
+        spanemuboost.WithSetupDDLs(ddls),
+    )
+    // use clients.Client...
+}
+
+func TestUnit(t *testing.T) {
+    // Does NOT use lazyEmu — emulator never starts
+}
+```
+
+#### Eager shared emulator
+
+`testing.M` does NOT implement `testing.TB`, so use `RunEmulator` directly in `TestMain`.
 
 ```go
 var emulator *spanemuboost.Emulator
@@ -75,9 +81,7 @@ func TestMain(m *testing.M) {
     )
     if err != nil { log.Fatal(err) }
     code := m.Run()
-    if err := emulator.Close(); err != nil {
-        log.Printf("failed to close emulator: %v", err)
-    }
+    emulator.Close()
     os.Exit(code)
 }
 
@@ -88,17 +92,9 @@ func TestCreate(t *testing.T) {
     )
     // use clients.Client...
 }
-
-func TestRead(t *testing.T) {
-    clients := spanemuboost.SetupClients(t, emulator,
-        spanemuboost.WithRandomDatabaseID(),
-        spanemuboost.WithSetupDDLs(ddls),
-    )
-    // use clients.Client...
-}
 ```
 
-### Shared emulator with subtests
+#### Shared emulator with subtests
 
 When tests are naturally related and don't need `TestMain`, you can share an emulator within subtests of a single parent test. Since each subtest creates its own database via `WithRandomDatabaseID()`, subtests can safely run in parallel with `t.Parallel()`.
 
@@ -114,21 +110,12 @@ func TestSuite(t *testing.T) {
         )
         // use clients.Client...
     })
-
-    t.Run("test2", func(t *testing.T) {
-        t.Parallel()
-        clients := spanemuboost.SetupClients(t, emu,
-            spanemuboost.WithRandomDatabaseID(),
-            spanemuboost.WithSetupDDLs(otherDDLs),
-        )
-        // use clients.Client...
-    })
 }
 ```
 
-### Using `SPANNER_EMULATOR_HOST` environment variable
+### `SPANNER_EMULATOR_HOST` environment variable
 
-For serial tests with code that reads `SPANNER_EMULATOR_HOST` directly instead of accepting a client, you can use `t.Setenv` to set the environment variable:
+For serial tests with code that reads `SPANNER_EMULATOR_HOST` directly:
 
 ```go
 func TestWithEnvVar(t *testing.T) {
@@ -138,59 +125,8 @@ func TestWithEnvVar(t *testing.T) {
 }
 ```
 
-**Caveats:**
-- `t.Setenv` cannot be used with `t.Parallel()` or tests with parallel ancestors (it panics).
-- The environment variable is process-global and doesn't scale to concurrent tests.
-- Prefer passing `emu.ClientOptions()` or clients directly when possible.
-
-### Multiple databases (non-test)
-
-```go
-func ExampleOpenClients() {
-    ctx := context.Background()
-
-    emu, err := spanemuboost.RunEmulator(ctx,
-        spanemuboost.EnableInstanceAutoConfigOnly(),
-    )
-    if err != nil {
-        log.Fatalln(err)
-        return
-    }
-
-    defer emu.Close()
-
-    var pks []int64
-    for i := range 10 {
-        func() {
-            clients, err := spanemuboost.OpenClients(ctx, emu,
-                spanemuboost.WithRandomDatabaseID(),
-                spanemuboost.WithSetupDDLs([]string{"CREATE TABLE tbl (PK INT64 PRIMARY KEY)"}),
-                spanemuboost.WithSetupDMLs([]spanner.Statement{
-                    {SQL: "INSERT INTO tbl(PK) VALUES(@i)", Params: map[string]any{"i": i}},
-                }),
-            )
-            if err != nil {
-                log.Fatalln(err)
-                return
-            }
-
-            defer clients.Close()
-
-            err = clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT PK FROM tbl")).Do(func(r *spanner.Row) error {
-                var pk int64
-                if err := r.ColumnByName("PK", &pk); err != nil {
-                    return err
-                }
-                pks = append(pks, pk)
-                return nil
-            })
-            if err != nil {
-                log.Fatalln(err)
-            }
-        }()
-    }
-
-    fmt.Println(pks)
-    // Output: [0 1 2 3 4 5 6 7 8 9]
-}
-```
+| Caveat | Detail |
+|---|---|
+| No `t.Parallel()` | `t.Setenv` panics if the test or an ancestor called `t.Parallel()` |
+| Process-global | The env var doesn't scale to concurrent tests |
+| Prefer `ClientOptions()` | Pass `emu.ClientOptions()` or clients directly when possible |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ var lazyEmu = spanemuboost.NewLazyEmulator(spanemuboost.EnableInstanceAutoConfig
 
 func TestMain(m *testing.M) {
     code := m.Run()
-    lazyEmu.Close() // no-op if no test used the emulator
+    if err := lazyEmu.Close(); err != nil { // no-op if no test used the emulator
+        log.Printf("failed to close emulator: %v", err)
+    }
     os.Exit(code)
 }
 
@@ -81,7 +83,9 @@ func TestMain(m *testing.M) {
     )
     if err != nil { log.Fatal(err) }
     code := m.Run()
-    emulator.Close()
+    if err := emulator.Close(); err != nil {
+        log.Printf("failed to close emulator: %v", err)
+    }
     os.Exit(code)
 }
 

--- a/emulator.go
+++ b/emulator.go
@@ -96,6 +96,9 @@ type LazyEmulator struct {
 	emu  *Emulator
 	err  error
 	opts []Option
+
+	closeOnce sync.Once
+	closeErr  error
 }
 
 // NewLazyEmulator creates a [LazyEmulator] that will start an emulator with the
@@ -111,7 +114,7 @@ func (le *LazyEmulator) get(ctx context.Context) (*Emulator, error) {
 		le.emu, le.err = RunEmulator(ctx, le.opts...)
 	})
 	if le.emu == nil && le.err == nil {
-		return nil, errors.New("spanemuboost: lazy emulator used after Close or without initialization")
+		return nil, errors.New("spanemuboost: lazy emulator used after Close was called before initialization")
 	}
 	return le.emu, le.err
 }
@@ -123,14 +126,17 @@ func (le *LazyEmulator) Get(ctx context.Context) (*Emulator, error) {
 }
 
 // Close terminates the emulator if it was started. No-op otherwise.
+// Close is idempotent — subsequent calls return the result of the first call.
 // Close waits for any in-progress initialization to complete before checking.
 // If Close is called before any Get or Setup, the emulator will never be started.
 func (le *LazyEmulator) Close() error {
 	le.once.Do(func() {})
-	if le.emu != nil {
-		return le.emu.Close()
-	}
-	return nil
+	le.closeOnce.Do(func() {
+		if le.emu != nil {
+			le.closeErr = le.emu.Close()
+		}
+	})
+	return le.closeErr
 }
 
 // Env combines an [Emulator] with [Clients] for the single-call use case.

--- a/emulator.go
+++ b/emulator.go
@@ -3,10 +3,18 @@ package spanemuboost
 import (
 	"context"
 	"errors"
+	"sync"
 
 	tcspanner "github.com/testcontainers/testcontainers-go/modules/gcloud/spanner"
 	"google.golang.org/api/option"
 )
+
+// abstractEmulator is satisfied by both [*Emulator] and [*LazyEmulator].
+// The unexported method prevents external implementations.
+// It allows [OpenClients] and [SetupClients] to accept either type.
+type abstractEmulator interface {
+	get(context.Context) (*Emulator, error)
+}
 
 // Emulator wraps a Cloud Spanner Emulator container.
 // Use [RunEmulator] or [SetupEmulator] to create one.
@@ -73,6 +81,50 @@ func (e *Emulator) InstancePath() string { return instancePath(e.opts.projectID,
 // DatabasePath returns the database resource path.
 func (e *Emulator) DatabasePath() string {
 	return databasePath(e.opts.projectID, e.opts.instanceID, e.opts.databaseID)
+}
+
+func (e *Emulator) get(_ context.Context) (*Emulator, error) {
+	return e, nil
+}
+
+// LazyEmulator defers emulator startup until first use.
+// Use [NewLazyEmulator] in a package-level var, then pass directly to [SetupClients]
+// or [OpenClients]. Call [LazyEmulator.Setup] or [LazyEmulator.Get] for standalone access.
+// [LazyEmulator.Close] is safe to call even if the emulator was never started (no-op).
+type LazyEmulator struct {
+	once sync.Once
+	emu  *Emulator
+	err  error
+	opts []Option
+}
+
+// NewLazyEmulator creates a [LazyEmulator] that will start an emulator with the
+// given options on first use. The emulator is not started until it is passed to
+// [SetupClients], [OpenClients], or until [LazyEmulator.Setup] / [LazyEmulator.Get]
+// is called directly.
+func NewLazyEmulator(options ...Option) *LazyEmulator {
+	return &LazyEmulator{opts: options}
+}
+
+func (le *LazyEmulator) get(ctx context.Context) (*Emulator, error) {
+	le.once.Do(func() {
+		le.emu, le.err = RunEmulator(ctx, le.opts...)
+	})
+	return le.emu, le.err
+}
+
+// Get starts the emulator on first call (thread-safe via [sync.Once]) and
+// returns the cached [*Emulator] on subsequent calls.
+func (le *LazyEmulator) Get(ctx context.Context) (*Emulator, error) {
+	return le.get(ctx)
+}
+
+// Close terminates the emulator if it was started. No-op otherwise.
+func (le *LazyEmulator) Close() error {
+	if le.emu != nil {
+		return le.emu.Close()
+	}
+	return nil
 }
 
 // Env combines an [Emulator] with [Clients] for the single-call use case.

--- a/emulator.go
+++ b/emulator.go
@@ -110,6 +110,9 @@ func (le *LazyEmulator) get(ctx context.Context) (*Emulator, error) {
 	le.once.Do(func() {
 		le.emu, le.err = RunEmulator(ctx, le.opts...)
 	})
+	if le.emu == nil && le.err == nil {
+		return nil, errors.New("spanemuboost: lazy emulator used after Close or without initialization")
+	}
 	return le.emu, le.err
 }
 
@@ -120,7 +123,10 @@ func (le *LazyEmulator) Get(ctx context.Context) (*Emulator, error) {
 }
 
 // Close terminates the emulator if it was started. No-op otherwise.
+// Close waits for any in-progress initialization to complete before checking.
+// If Close is called before any Get or Setup, the emulator will never be started.
 func (le *LazyEmulator) Close() error {
+	le.once.Do(func() {})
 	if le.emu != nil {
 		return le.emu.Close()
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -79,6 +79,39 @@ func ExampleOpenClients() {
 	// Output: [0 1 2 3 4 5 6 7 8 9]
 }
 
+func ExampleLazyEmulator_Get() {
+	ctx := context.Background()
+
+	lazy := spanemuboost.NewLazyEmulator(
+		spanemuboost.EnableInstanceAutoConfigOnly(),
+	)
+	defer lazy.Close() //nolint:errcheck
+
+	// Get starts the emulator on first call.
+	// Subsequent calls return the cached emulator.
+	emu, err := lazy.Get(ctx)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	clients, err := spanemuboost.OpenClients(ctx, emu,
+		spanemuboost.WithRandomDatabaseID(),
+	)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer clients.Close() //nolint:errcheck
+
+	err = clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1")).Do(func(r *spanner.Row) error {
+		fmt.Println(r)
+		return nil
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+	// Output: {fields: [type:{code:INT64}], values: [string_value:"1"]}
+}
+
 // Deprecated examples kept for backward compatibility testing.
 
 func ExampleNewEmulatorWithClients() {

--- a/example_test.go
+++ b/example_test.go
@@ -85,7 +85,11 @@ func ExampleLazyEmulator_Get() {
 	lazy := spanemuboost.NewLazyEmulator(
 		spanemuboost.EnableInstanceAutoConfigOnly(),
 	)
-	defer lazy.Close() //nolint:errcheck
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			log.Printf("failed to close lazy emulator: %v", err)
+		}
+	}()
 
 	// Get starts the emulator on first call.
 	// Subsequent calls return the cached emulator.
@@ -100,7 +104,11 @@ func ExampleLazyEmulator_Get() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	defer clients.Close() //nolint:errcheck
+	defer func() {
+		if err := clients.Close(); err != nil {
+			log.Printf("failed to close clients: %v", err)
+		}
+	}()
 
 	err = clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1")).Do(func(r *spanner.Row) error {
 		fmt.Println(r)

--- a/internal.go
+++ b/internal.go
@@ -272,6 +272,8 @@ func bootstrapAndCreateClients(ctx context.Context, emu *Emulator, opts *emulato
 		ProjectID:      opts.projectID,
 		InstanceID:     opts.instanceID,
 		DatabaseID:     opts.databaseID,
+		clientOpts:     clientOpts,
+		uri:            emu.URI(),
 		dropDatabase:   opts.shouldDropDatabase(),
 		dropInstance:   opts.shouldDropInstance(),
 	}, nil
@@ -323,6 +325,8 @@ func newClients(ctx context.Context, emulator *tcspanner.Container, opts *emulat
 		ProjectID:      opts.projectID,
 		InstanceID:     opts.instanceID,
 		DatabaseID:     opts.databaseID,
+		clientOpts:     clientOpts,
+		uri:            emulator.URI(),
 	}, teardown, nil
 }
 

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -11,6 +11,7 @@ import (
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
 	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
 	tcspanner "github.com/testcontainers/testcontainers-go/modules/gcloud/spanner"
+	"google.golang.org/api/option"
 )
 
 const (
@@ -37,6 +38,9 @@ type Clients struct {
 
 	ProjectID, InstanceID, DatabaseID string
 
+	clientOpts []option.ClientOption
+	uri        string
+
 	dropDatabase bool
 	dropInstance bool
 }
@@ -44,6 +48,20 @@ type Clients struct {
 func (c *Clients) ProjectPath() string  { return projectPath(c.ProjectID) }
 func (c *Clients) InstancePath() string { return instancePath(c.ProjectID, c.InstanceID) }
 func (c *Clients) DatabasePath() string { return databasePath(c.ProjectID, c.InstanceID, c.DatabaseID) }
+
+// ClientOptions returns the [option.ClientOption] values used to connect to the
+// emulator. This is useful when callers need to create additional gRPC clients
+// (e.g., with custom interceptors) against the same emulator without holding a
+// separate [*Emulator] reference.
+func (c *Clients) ClientOptions() []option.ClientOption {
+	return c.clientOpts
+}
+
+// URI returns the gRPC endpoint (host:port) of the emulator this [Clients]
+// is connected to, suitable for use as SPANNER_EMULATOR_HOST.
+func (c *Clients) URI() string {
+	return c.uri
+}
 
 // Close closes all Spanner clients.
 // By default, auto-created resources with fixed IDs are dropped before

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -136,15 +136,22 @@ func RunEmulatorWithClients(ctx context.Context, options ...Option) (*Env, error
 	return &Env{Clients: clients, emulator: emu}, nil
 }
 
-// OpenClients connects to an existing [Emulator] and opens Spanner clients.
+// OpenClients connects to an existing emulator and opens Spanner clients.
+// The emu parameter accepts both [*Emulator] and [*LazyEmulator].
+// When a [*LazyEmulator] is passed, the emulator is started automatically on first use.
 // Options inherit the emulator's projectID and instanceID; instance creation
 // is disabled by default (use [EnableAutoConfig] to override).
 // Call [Clients.Close] to close the clients when done.
 // In tests, prefer [SetupClients] which handles cleanup automatically.
-func OpenClients(ctx context.Context, emu *Emulator, options ...Option) (*Clients, error) {
+func OpenClients(ctx context.Context, emu abstractEmulator, options ...Option) (*Clients, error) {
+	e, err := emu.get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	base := &emulatorOptions{
-		projectID:             emu.opts.projectID,
-		instanceID:            emu.opts.instanceID,
+		projectID:             e.opts.projectID,
+		instanceID:            e.opts.instanceID,
 		disableCreateInstance: true,
 	}
 
@@ -153,7 +160,7 @@ func OpenClients(ctx context.Context, emu *Emulator, options ...Option) (*Client
 		return nil, err
 	}
 
-	return bootstrapAndCreateClients(ctx, emu, opts)
+	return bootstrapAndCreateClients(ctx, e, opts)
 }
 
 // Deprecated: Use [SetupEmulator] (for tests) or [RunEmulator] instead.

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -1,6 +1,7 @@
 package spanemuboost
 
 import (
+	"sync"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -460,6 +461,38 @@ func TestLazyEmulatorClientsAccessors(t *testing.T) {
 	}
 	if uri := clients.URI(); uri == "" {
 		t.Error("URI() is empty")
+	}
+}
+
+func TestLazyEmulatorConcurrentGet(t *testing.T) {
+	lazy := NewLazyEmulator(EnableInstanceAutoConfigOnly())
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			t.Errorf("failed to close lazy emulator: %v", err)
+		}
+	}()
+
+	const goroutines = 10
+	emus := make([]*Emulator, goroutines)
+	errs := make([]error, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func() {
+			defer wg.Done()
+			emus[i], errs[i] = lazy.Get(t.Context())
+		}()
+	}
+	wg.Wait()
+
+	for i := range goroutines {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d: Get() failed: %v", i, errs[i])
+		}
+		if emus[i] != emus[0] {
+			t.Errorf("goroutine %d: Get() returned different instance", i)
+		}
 	}
 }
 

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -370,6 +370,23 @@ func TestEmulatorAccessors(t *testing.T) {
 	}
 }
 
+func TestClientsAccessors(t *testing.T) {
+	emu := SetupEmulator(t, EnableInstanceAutoConfigOnly())
+
+	clients := SetupClients(t, emu,
+		WithRandomDatabaseID(),
+	)
+
+	if opts := clients.ClientOptions(); len(opts) != 4 {
+		t.Errorf("ClientOptions() returned %d options, want 4", len(opts))
+	}
+	if uri := clients.URI(); uri == "" {
+		t.Error("URI() is empty")
+	} else if uri != emu.URI() {
+		t.Errorf("URI() = %q, want %q (from emulator)", uri, emu.URI())
+	}
+}
+
 func TestLazyEmulatorWithSetupClients(t *testing.T) {
 	ddls := []string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}
 
@@ -421,6 +438,29 @@ func TestLazyEmulatorWithOpenClients(t *testing.T) {
 	}()
 
 	mustConsumeQuery(t, clients, "SELECT 1")
+}
+
+func TestLazyEmulatorClientsAccessors(t *testing.T) {
+	// Verify that Clients.ClientOptions() and Clients.URI() work when
+	// created via SetupClients with a LazyEmulator, so callers don't need
+	// a separate *Emulator reference for connection info.
+	lazy := NewLazyEmulator(EnableInstanceAutoConfigOnly())
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			t.Errorf("failed to close lazy emulator: %v", err)
+		}
+	}()
+
+	clients := SetupClients(t, lazy,
+		WithRandomDatabaseID(),
+	)
+
+	if opts := clients.ClientOptions(); len(opts) != 4 {
+		t.Errorf("ClientOptions() returned %d options, want 4", len(opts))
+	}
+	if uri := clients.URI(); uri == "" {
+		t.Error("URI() is empty")
+	}
 }
 
 func TestLazyEmulatorGetReturnsSameInstance(t *testing.T) {

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -370,6 +370,100 @@ func TestEmulatorAccessors(t *testing.T) {
 	}
 }
 
+func TestLazyEmulatorWithSetupClients(t *testing.T) {
+	ddls := []string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}
+
+	lazy := NewLazyEmulator(EnableInstanceAutoConfigOnly())
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			t.Errorf("failed to close lazy emulator: %v", err)
+		}
+	}()
+
+	t.Run("first call starts emulator", func(t *testing.T) {
+		clients := SetupClients(t, lazy,
+			WithRandomDatabaseID(),
+			WithSetupDDLs(ddls),
+		)
+		mustConsumeQuery(t, clients, "SELECT 1")
+	})
+
+	t.Run("second call reuses emulator", func(t *testing.T) {
+		clients := SetupClients(t, lazy,
+			WithRandomDatabaseID(),
+			WithSetupDDLs(ddls),
+		)
+		mustConsumeQuery(t, clients, "SELECT 1")
+	})
+}
+
+func TestLazyEmulatorWithOpenClients(t *testing.T) {
+	ddls := []string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}
+
+	lazy := NewLazyEmulator(EnableInstanceAutoConfigOnly())
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			t.Errorf("failed to close lazy emulator: %v", err)
+		}
+	}()
+
+	clients, err := OpenClients(t.Context(), lazy,
+		WithRandomDatabaseID(),
+		WithSetupDDLs(ddls),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := clients.Close(); err != nil {
+			t.Errorf("failed to close clients: %v", err)
+		}
+	}()
+
+	mustConsumeQuery(t, clients, "SELECT 1")
+}
+
+func TestLazyEmulatorGetReturnsSameInstance(t *testing.T) {
+	lazy := NewLazyEmulator(EnableInstanceAutoConfigOnly())
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			t.Errorf("failed to close lazy emulator: %v", err)
+		}
+	}()
+
+	ctx := t.Context()
+	emu1, err := lazy.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emu2, err := lazy.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if emu1 != emu2 {
+		t.Error("Get() returned different instances")
+	}
+}
+
+func TestLazyEmulatorCloseWithoutStart(t *testing.T) {
+	lazy := NewLazyEmulator(EnableInstanceAutoConfigOnly())
+	if err := lazy.Close(); err != nil {
+		t.Fatalf("Close() on unused LazyEmulator should be no-op, got: %v", err)
+	}
+}
+
+func TestLazyEmulatorGetAfterClose(t *testing.T) {
+	lazy := NewLazyEmulator(EnableInstanceAutoConfigOnly())
+	if err := lazy.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := lazy.Get(t.Context())
+	if err == nil {
+		t.Fatal("Get() after Close() should return an error")
+	}
+}
+
 func sliceOf[T any](values ...T) []T {
 	return values
 }

--- a/testing.go
+++ b/testing.go
@@ -4,6 +4,20 @@ import (
 	"testing"
 )
 
+// Setup starts the emulator on first call (thread-safe via [sync.Once]) and
+// returns the cached [*Emulator] on subsequent calls.
+// It calls [testing.TB.Fatal] if startup fails.
+// For use with [SetupClients] or [OpenClients], you can pass [*LazyEmulator] directly
+// without calling Setup.
+func (le *LazyEmulator) Setup(tb testing.TB) *Emulator {
+	tb.Helper()
+	emu, err := le.Get(tb.Context())
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return emu
+}
+
 // SetupEmulator starts a Cloud Spanner Emulator and registers cleanup via [testing.TB.Cleanup].
 // It calls [testing.TB.Fatal] on setup error.
 // Use [RunEmulator] if you need a [context.Context] or are not in a test.
@@ -45,10 +59,12 @@ func SetupEmulatorWithClients(tb testing.TB, options ...Option) *Env {
 	return env
 }
 
-// SetupClients opens Spanner clients against an existing [Emulator] and registers
+// SetupClients opens Spanner clients against an existing emulator and registers
 // cleanup via [testing.TB.Cleanup]. It calls [testing.TB.Fatal] on setup error.
+// The emu parameter accepts both [*Emulator] and [*LazyEmulator].
+// When a [*LazyEmulator] is passed, the emulator is started automatically on first use.
 // Use [OpenClients] if you need a [context.Context] or are not in a test.
-func SetupClients(tb testing.TB, emu *Emulator, options ...Option) *Clients {
+func SetupClients(tb testing.TB, emu abstractEmulator, options ...Option) *Clients {
 	tb.Helper()
 
 	clients, err := OpenClients(tb.Context(), emu, options...)


### PR DESCRIPTION
## Summary
- Add `LazyEmulator` type that defers emulator container startup until first use via `sync.Once`
- `SetupClients` and `OpenClients` now accept both `*Emulator` and `*LazyEmulator` via the unexported `abstractEmulator` interface — existing callers are unaffected
- Restructure README: tables for pattern comparison, replace duplicated non-test code samples with pkg.go.dev links
- Add `ExampleLazyEmulator_Get` as a runnable example

## Design decisions
- **`abstractEmulator` interface with `get(context.Context) (*Emulator, error)`** — `testing`-free, works for both `OpenClients` (non-test) and `SetupClients` (test)
- **Error stored in struct, not fataled inside `sync.Once.Do`** — `tb.Fatal` calls `runtime.Goexit()` which would mark `sync.Once` as done but leave `emu` nil
- **`Close()` is no-op if never started** — safe to call unconditionally in `TestMain`

## Recommended usage
```go
var lazyEmu = spanemuboost.NewLazyEmulator(spanemuboost.EnableInstanceAutoConfigOnly())

func TestMain(m *testing.M) {
    code := m.Run()
    lazyEmu.Close() // no-op if no test used the emulator
    os.Exit(code)
}

func TestCreate(t *testing.T) {
    clients := spanemuboost.SetupClients(t, lazyEmu, // starts emulator on first call
        spanemuboost.WithRandomDatabaseID(),
        spanemuboost.WithSetupDDLs(ddls),
    )
}

func TestUnit(t *testing.T) {
    // Does NOT use lazyEmu — emulator never starts
}
```

## Test plan
- [ ] `go build ./...` && `go vet ./...` && `golangci-lint run` — all pass
- [ ] `go test -count=1 ./...` — existing tests still pass
- [ ] `go test -run TestResourcePaths -count=1 ./...` — passes without starting an emulator
- [ ] Review godoc renders correctly for new types and methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)