### PR TITLE
Add LazyRuntime and harden lazy startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ func TestSharedHelpers(t *testing.T) {
 }
 ```
 
-`Run`, `RunWithClients`, `Setup`, `SetupWithClients`, `OpenClients`, and `SetupClients` work across emulator and Omni. `BackendOmni` is the backend selector; Omni does not add separate exported startup or client-opening helpers.
+`Run`, `RunWithClients`, `Setup`, `SetupWithClients`, `OpenClients`, `SetupClients`, and `NewLazyRuntime` work across emulator and Omni. `BackendOmni` is the backend selector; Omni does not add separate exported startup or client-opening helpers.
 
 ### Shared emulator patterns
 
@@ -90,21 +90,24 @@ As [recommended by the Cloud Spanner Emulator FAQ](https://github.com/GoogleClou
 
 | Pattern | Emulator lifetime | Best for |
 |---|---|---|
-| **Lazy** (`NewLazyEmulator` + `SetupClients`) | First `SetupClients` call &rarr; `TestMain` cleanup | Packages mixing emulator and non-emulator tests; skips startup when unused |
+| **Lazy** (`NewLazyRuntime(BackendEmulator, ...)` + `SetupClients`) | First `SetupClients` call &rarr; `TestMain` cleanup | Packages mixing emulator and non-emulator tests; skips startup when unused |
 | **Eager** (`RunEmulator` + `SetupClients`) | `TestMain` start &rarr; `TestMain` cleanup | All tests need the emulator; fail fast on startup errors |
 | **Subtests** (`SetupEmulator` + `SetupClients`) | Parent test &rarr; `t.Cleanup` | Related tests grouped under one function; supports `t.Parallel()` in subtests |
 
 #### Lazy shared emulator (recommended)
 
-The emulator starts only when the first test calls `SetupClients` with the `LazyEmulator`. If `go test -run TestUnit` matches only tests that never use it, the container is never started.
+The emulator starts only when the first test calls `SetupClients` with the `LazyRuntime`. If `go test -run TestUnit` matches only tests that never use it, the container is never started.
 
 ```go
-var lazyEmu = spanemuboost.NewLazyEmulator(spanemuboost.EnableInstanceAutoConfigOnly())
+var lazyRuntime = spanemuboost.NewLazyRuntime(
+    spanemuboost.BackendEmulator,
+    spanemuboost.EnableInstanceAutoConfigOnly(),
+)
 
-func TestMain(m *testing.M) { lazyEmu.TestMain(m) }
+func TestMain(m *testing.M) { lazyRuntime.TestMain(m) }
 
 func TestCreate(t *testing.T) {
-    clients := spanemuboost.SetupClients(t, lazyEmu,
+    clients := spanemuboost.SetupClients(t, lazyRuntime,
         spanemuboost.WithRandomDatabaseID(),
         spanemuboost.WithSetupDDLs(ddls),
     )
@@ -112,9 +115,17 @@ func TestCreate(t *testing.T) {
 }
 
 func TestUnit(t *testing.T) {
-    // Does NOT use lazyEmu — emulator never starts
+    // Does NOT use lazyRuntime — emulator never starts
 }
 ```
+
+`NewLazyEmulator` remains available as a backward-compatible wrapper around the
+emulator backend, but `NewLazyRuntime(BackendEmulator, ...)` can cover the same
+shared-runtime patterns while also extending naturally to Omni.
+
+When you need emulator-specific helpers such as `Container()`, call
+`runtime := lazyRuntime.Setup(t)` (or `Get(ctx)`) and type assert the result back
+to `*spanemuboost.Emulator` for the `BackendEmulator` case.
 
 #### Eager shared emulator
 
@@ -147,11 +158,16 @@ When tests are naturally related and don't need `TestMain`, you can share an emu
 
 ```go
 func TestSuite(t *testing.T) {
-    emu := spanemuboost.SetupEmulator(t, spanemuboost.EnableInstanceAutoConfigOnly())
+    lazy := spanemuboost.NewLazyRuntime(
+        spanemuboost.BackendEmulator,
+        spanemuboost.EnableInstanceAutoConfigOnly(),
+    )
+    t.Cleanup(func() { _ = lazy.Close() })
+    runtime := lazy.Setup(t)
 
     t.Run("test1", func(t *testing.T) {
         t.Parallel()
-        clients := spanemuboost.SetupClients(t, emu,
+        clients := spanemuboost.SetupClients(t, runtime,
             spanemuboost.WithRandomDatabaseID(),
             spanemuboost.WithSetupDDLs(ddls),
         )
@@ -166,8 +182,13 @@ For serial tests with code that reads `SPANNER_EMULATOR_HOST` directly:
 
 ```go
 func TestWithEnvVar(t *testing.T) {
-    emu := spanemuboost.SetupEmulator(t, spanemuboost.EnableInstanceAutoConfigOnly())
-    t.Setenv("SPANNER_EMULATOR_HOST", emu.URI())
+    lazy := spanemuboost.NewLazyRuntime(
+        spanemuboost.BackendEmulator,
+        spanemuboost.EnableInstanceAutoConfigOnly(),
+    )
+    t.Cleanup(func() { _ = lazy.Close() })
+    runtime := lazy.Setup(t)
+    t.Setenv("SPANNER_EMULATOR_HOST", runtime.URI())
     // Code under test that reads SPANNER_EMULATOR_HOST directly
 }
 ```
@@ -176,4 +197,4 @@ func TestWithEnvVar(t *testing.T) {
 |---|---|
 | No `t.Parallel()` | `t.Setenv` panics if the test or an ancestor called `t.Parallel()` |
 | Process-global | The env var doesn't scale to concurrent tests |
-| Prefer `ClientOptions()` | Pass `emu.ClientOptions()` or clients directly when possible |
+| Prefer `ClientOptions()` | Pass `runtime.ClientOptions()` or clients directly when possible |

--- a/emulator.go
+++ b/emulator.go
@@ -3,7 +3,6 @@ package spanemuboost
 import (
 	"context"
 	"errors"
-	"sync"
 
 	tcspanner "github.com/testcontainers/testcontainers-go/modules/gcloud/spanner"
 	"google.golang.org/api/option"
@@ -88,13 +87,8 @@ func (e *Emulator) inheritedOptions(options ...Option) (*emulatorOptions, error)
 // or [OpenClients]. Call [LazyEmulator.Setup] or [LazyEmulator.Get] for standalone access.
 // [LazyEmulator.Close] is safe to call even if the emulator was never started (no-op).
 type LazyEmulator struct {
-	once sync.Once
-	emu  *Emulator
-	err  error
-	opts []Option
-
-	closeOnce sync.Once
-	closeErr  error
+	state lazyRuntimeState
+	opts  []Option
 }
 
 func (*LazyEmulator) spanemuboostRuntime() {}
@@ -108,13 +102,9 @@ func NewLazyEmulator(options ...Option) *LazyEmulator {
 }
 
 func (le *LazyEmulator) get(ctx context.Context) (runtimeInstance, error) {
-	le.once.Do(func() {
-		le.emu, le.err = RunEmulator(ctx, le.opts...)
-	})
-	if le.emu == nil && le.err == nil {
-		return nil, errors.New("spanemuboost: lazy emulator used after Close was called before initialization")
-	}
-	return le.emu, le.err
+	return le.state.get(ctx, func(ctx context.Context) (runtimeInstance, error) {
+		return RunEmulator(ctx, le.opts...)
+	}, "spanemuboost: lazy emulator used after Close was called before initialization")
 }
 
 // Get starts the emulator on first call (thread-safe via [sync.Once]) and
@@ -136,13 +126,7 @@ func (le *LazyEmulator) Get(ctx context.Context) (*Emulator, error) {
 // Close waits for any in-progress initialization to complete before checking.
 // If Close is called before any Get or Setup, the emulator will never be started.
 func (le *LazyEmulator) Close() error {
-	le.once.Do(func() {})
-	le.closeOnce.Do(func() {
-		if le.emu != nil {
-			le.closeErr = le.emu.Close()
-		}
-	})
-	return le.closeErr
+	return le.state.close()
 }
 
 // Env combines an [Emulator] with [Clients] for the single-call use case.

--- a/example_test.go
+++ b/example_test.go
@@ -115,6 +115,43 @@ func ExampleLazyEmulator() {
 	// Output: {fields: [type:{code:INT64}], values: [string_value:"1"]}
 }
 
+func ExampleLazyRuntime() {
+	ctx := context.Background()
+
+	lazy := spanemuboost.NewLazyRuntime(
+		spanemuboost.BackendEmulator,
+		spanemuboost.EnableInstanceAutoConfigOnly(),
+	)
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			log.Printf("failed to close lazy runtime: %v", err)
+		}
+	}()
+
+	// OpenClients accepts a *LazyRuntime directly and starts it on first use.
+	clients, err := spanemuboost.OpenClients(ctx, lazy,
+		spanemuboost.WithRandomDatabaseID(),
+	)
+	if err != nil {
+		log.Fatalln(err)
+		return
+	}
+	defer func() {
+		if err := clients.Close(); err != nil {
+			log.Printf("failed to close clients: %v", err)
+		}
+	}()
+
+	err = clients.Client.Single().Query(ctx, spanner.NewStatement("SELECT 1")).Do(func(r *spanner.Row) error {
+		fmt.Println(r)
+		return nil
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+	// Output: {fields: [type:{code:INT64}], values: [string_value:"1"]}
+}
+
 // Deprecated examples kept for backward compatibility testing.
 
 func ExampleNewEmulatorWithClients() {

--- a/lazy.go
+++ b/lazy.go
@@ -21,14 +21,18 @@ type lazyRuntimeState struct {
 
 func (s *lazyRuntimeState) get(ctx context.Context, start func(context.Context) (runtimeInstance, error), missingMessage string) (runtimeInstance, error) {
 	s.once.Do(func() {
+		panicking := true
 		defer func() {
-			if r := recover(); r != nil {
+			// Track whether start panicked separately so panic(nil) is not
+			// mistaken for a normal return and later translated into missingMessage.
+			if panicking {
 				s.panicked = true
-				s.panicValue = r
-				panic(r)
+				s.panicValue = recover()
+				panic(s.panicValue)
 			}
 		}()
 		s.runtime, s.err = start(ctx)
+		panicking = false
 	})
 	if s.panicked {
 		panic(s.panicValue)

--- a/lazy.go
+++ b/lazy.go
@@ -1,0 +1,108 @@
+package spanemuboost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+type lazyRuntimeState struct {
+	once    sync.Once
+	runtime runtimeInstance
+	err     error
+
+	panicked   bool
+	panicValue any
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func (s *lazyRuntimeState) get(ctx context.Context, start func(context.Context) (runtimeInstance, error), missingMessage string) (runtimeInstance, error) {
+	s.once.Do(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				s.panicked = true
+				s.panicValue = r
+				panic(r)
+			}
+		}()
+		s.runtime, s.err = start(ctx)
+	})
+	if s.panicked {
+		panic(s.panicValue)
+	}
+	if (s.runtime == nil || isNilRuntimeValue(s.runtime)) && s.err == nil {
+		return nil, errors.New(missingMessage)
+	}
+	if s.runtime == nil || isNilRuntimeValue(s.runtime) {
+		return nil, s.err
+	}
+	return s.runtime, s.err
+}
+
+func (s *lazyRuntimeState) close() error {
+	s.once.Do(func() {})
+	s.closeOnce.Do(func() {
+		if s.runtime != nil && !isNilRuntimeValue(s.runtime) {
+			s.closeErr = s.runtime.Close()
+		}
+	})
+	return s.closeErr
+}
+
+// LazyRuntime defers startup of the selected backend until first use.
+// Use [NewLazyRuntime] in a package-level var, then pass it directly to
+// [SetupClients] or [OpenClients]. Call [LazyRuntime.Setup] or [LazyRuntime.Get]
+// for standalone access, and pair it with [LazyRuntime.Close] or [LazyRuntime.TestMain]
+// when you need the lazy handle to own lifecycle cleanup. [LazyRuntime.Close] is
+// safe to call even if the runtime was never started (no-op).
+type LazyRuntime struct {
+	state   lazyRuntimeState
+	backend Backend
+	opts    []Option
+}
+
+func (*LazyRuntime) spanemuboostRuntime() {}
+
+// NewLazyRuntime creates a [LazyRuntime] that will start the selected backend
+// with the given options on first use.
+func NewLazyRuntime(backend Backend, options ...Option) *LazyRuntime {
+	return &LazyRuntime{
+		backend: backend,
+		opts:    options,
+	}
+}
+
+func (lr *LazyRuntime) get(ctx context.Context) (runtimeInstance, error) {
+	return lr.state.get(ctx, func(ctx context.Context) (runtimeInstance, error) {
+		runtime, err := Run(ctx, lr.backend, lr.opts...)
+		if err != nil {
+			return nil, err
+		}
+		instance, ok := runtime.(runtimeInstance)
+		if !ok {
+			return nil, fmt.Errorf("spanemuboost: lazy runtime backend %q returned unexpected runtime type %T", lr.backend, runtime)
+		}
+		return instance, nil
+	}, "spanemuboost: lazy runtime used after Close was called before initialization")
+}
+
+// Get starts the selected backend on first call (thread-safe via [sync.Once])
+// and returns the cached [Runtime] on subsequent calls.
+func (lr *LazyRuntime) Get(ctx context.Context) (Runtime, error) {
+	runtime, err := lr.get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return runtime, nil
+}
+
+// Close terminates the runtime if it was started. No-op otherwise.
+// Close is idempotent — subsequent calls return the result of the first call.
+// Close waits for any in-progress initialization to complete before checking.
+// If Close is called before any Get or Setup, the runtime will never be started.
+func (lr *LazyRuntime) Close() error {
+	return lr.state.close()
+}

--- a/lazy_test.go
+++ b/lazy_test.go
@@ -20,8 +20,6 @@ func TestLazyEmulatorCloseAfterFailedGet(t *testing.T) {
 }
 
 func TestLazyRuntimeStateGetRepanicsAfterStartPanic(t *testing.T) {
-	t.Helper()
-
 	var state lazyRuntimeState
 	const want = "boom"
 
@@ -42,4 +40,28 @@ func TestLazyRuntimeStateGetRepanicsAfterStartPanic(t *testing.T) {
 
 	assertPanic(1)
 	assertPanic(2)
+}
+
+func TestLazyRuntimeStateGetRepanicsAfterNilPanic(t *testing.T) {
+	var state lazyRuntimeState
+
+	assertPanics := func(call int) {
+		t.Helper()
+
+		panicking := true
+		defer func() {
+			_ = recover()
+			if !panicking {
+				t.Fatalf("call %d: get() returned normally, want panic", call)
+			}
+		}()
+
+		_, _ = state.get(t.Context(), func(context.Context) (runtimeInstance, error) {
+			panic(nil)
+		}, "unused")
+		panicking = false
+	}
+
+	assertPanics(1)
+	assertPanics(2)
 }

--- a/lazy_test.go
+++ b/lazy_test.go
@@ -1,0 +1,45 @@
+package spanemuboost
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLazyEmulatorCloseAfterFailedGet(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	lazy := NewLazyEmulator()
+	if _, err := lazy.Get(ctx); err == nil {
+		t.Fatal("Get() error = nil, want non-nil")
+	}
+
+	if err := lazy.Close(); err != nil {
+		t.Fatalf("Close() after failed Get() error = %v, want nil", err)
+	}
+}
+
+func TestLazyRuntimeStateGetRepanicsAfterStartPanic(t *testing.T) {
+	t.Helper()
+
+	var state lazyRuntimeState
+	const want = "boom"
+
+	assertPanic := func(call int) {
+		t.Helper()
+
+		defer func() {
+			if got := recover(); got != want {
+				t.Fatalf("call %d: panic = %v, want %q", call, got, want)
+			}
+		}()
+
+		_, _ = state.get(t.Context(), func(context.Context) (runtimeInstance, error) {
+			panic(want)
+		}, "unused")
+		t.Fatalf("call %d: get() returned normally, want panic", call)
+	}
+
+	assertPanic(1)
+	assertPanic(2)
+}

--- a/omni_test.go
+++ b/omni_test.go
@@ -439,6 +439,40 @@ func TestSetupClientsWithOmni(t *testing.T) {
 	}
 }
 
+func TestLazyRuntimeWithOmni(t *testing.T) {
+	if os.Getenv("SPANEMUBOOST_ENABLE_OMNI_TESTS") == "" {
+		t.Skip("set SPANEMUBOOST_ENABLE_OMNI_TESTS=1 to run Spanner Omni tests")
+	}
+
+	lazy := NewLazyRuntime(BackendOmni)
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			t.Errorf("failed to close lazy runtime: %v", err)
+		}
+	}()
+
+	clients := SetupClients(t, lazy,
+		WithRandomDatabaseID(),
+		WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX), col INT64) PRIMARY KEY (pk)"}),
+		WithSetupRawDMLs([]string{"INSERT INTO tbl (pk, col) VALUES ('lazy', 7)"}),
+	)
+
+	iter := clients.Client.Single().Query(t.Context(), spanner.NewStatement("SELECT col FROM tbl WHERE pk = 'lazy'"))
+	err := iter.Do(func(r *spanner.Row) error {
+		var col int64
+		if err := r.Column(0, &col); err != nil {
+			return err
+		}
+		if col != 7 {
+			t.Fatalf("col = %d, want 7", col)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRunInvalidBackend(t *testing.T) {
 	_, err := Run(context.Background(), Backend("invalid"))
 	if err == nil {

--- a/runtime.go
+++ b/runtime.go
@@ -70,11 +70,12 @@ func disableSchemaTeardownUnlessForced(opts *emulatorOptions, clients *Clients) 
 	}
 }
 
-// OpenClients and SetupClients intentionally accept either a started Runtime or
-// a *LazyEmulator without adding another startup method to the public Runtime API.
+// OpenClients and SetupClients intentionally accept either a started Runtime,
+// a *LazyRuntime, or a *LazyEmulator without adding another startup method to
+// the public Runtime API.
 func resolveRuntime(ctx context.Context, runtime abstractRuntime) (runtimeInstance, error) {
 	if runtime == nil {
-		return nil, errors.New("spanemuboost: runtime is nil; use *Emulator, *LazyEmulator, or a Runtime returned by Run or Setup")
+		return nil, errors.New("spanemuboost: runtime is nil; use *Emulator, *LazyRuntime, *LazyEmulator, or a Runtime returned by Run or Setup")
 	}
 
 	switch r := runtime.(type) {
@@ -83,6 +84,11 @@ func resolveRuntime(ctx context.Context, runtime abstractRuntime) (runtimeInstan
 			return nil, errors.New("spanemuboost: runtime is a nil *Emulator")
 		}
 		return r, nil
+	case *LazyRuntime:
+		if r == nil {
+			return nil, errors.New("spanemuboost: runtime is a nil *LazyRuntime")
+		}
+		return r.get(ctx)
 	case *LazyEmulator:
 		if r == nil {
 			return nil, errors.New("spanemuboost: runtime is a nil *LazyEmulator")
@@ -98,10 +104,10 @@ func resolveRuntime(ctx context.Context, runtime abstractRuntime) (runtimeInstan
 		case *omniRuntime:
 			return instance, nil
 		default:
-			return nil, fmt.Errorf("spanemuboost: unsupported runtime type %T; use *Emulator, *LazyEmulator, or a Runtime returned by Run or Setup", runtime)
+			return nil, fmt.Errorf("spanemuboost: unsupported runtime type %T; use *Emulator, *LazyRuntime, *LazyEmulator, or a Runtime returned by Run or Setup", runtime)
 		}
 	default:
-		return nil, fmt.Errorf("spanemuboost: unsupported runtime type %T; use *Emulator, *LazyEmulator, or a Runtime returned by Run or Setup", runtime)
+		return nil, fmt.Errorf("spanemuboost: unsupported runtime type %T; use *Emulator, *LazyRuntime, *LazyEmulator, or a Runtime returned by Run or Setup", runtime)
 	}
 }
 

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -151,12 +151,12 @@ func RunEmulatorWithClients(ctx context.Context, options ...Option) (*Env, error
 }
 
 // OpenClients connects to an existing runtime and opens Spanner clients.
-// The runtime parameter accepts [*Emulator], [*LazyEmulator], and the [Runtime]
-// returned by [Run] or [Setup].
-// When a [*LazyEmulator] is passed, the emulator is started automatically on first use.
+// The runtime parameter accepts [*Emulator], [*LazyRuntime], [*LazyEmulator],
+// and the [Runtime] returned by [Run] or [Setup].
+// When a lazy runtime is passed, it is started automatically on first use.
 // The parameter type is intentionally limited to package-provided runtime values
-// so callers can use [*LazyEmulator] without adding another startup method to
-// the public [Runtime] interface.
+// so callers can use lazy runtime handles without adding another startup method
+// to the public [Runtime] interface.
 // Options inherit the runtime's projectID, instanceID, and databaseID. When
 // reopening against an existing runtime, automatic create and teardown behavior
 // is disabled by default, so clients target the existing instance and database

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -373,6 +373,12 @@ func TestOpenClientsRejectsNilRuntime(t *testing.T) {
 		t.Fatal("OpenClients(nil *Emulator) error = nil, want non-nil")
 	}
 
+	var nilLazyRuntime *LazyRuntime
+	_, err = OpenClients(t.Context(), nilLazyRuntime)
+	if err == nil {
+		t.Fatal("OpenClients(nil *LazyRuntime) error = nil, want non-nil")
+	}
+
 	var nilLazy *LazyEmulator
 	_, err = OpenClients(t.Context(), nilLazy)
 	if err == nil {
@@ -647,6 +653,159 @@ func TestLazyEmulatorCloseWithoutStart(t *testing.T) {
 
 func TestLazyEmulatorGetAfterClose(t *testing.T) {
 	lazy := NewLazyEmulator(EnableInstanceAutoConfigOnly())
+	if err := lazy.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := lazy.Get(t.Context())
+	if err == nil {
+		t.Fatal("Get() after Close() should return an error")
+	}
+}
+
+func TestLazyRuntimeEmulatorWithSetupClients(t *testing.T) {
+	ddls := []string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}
+
+	lazy := NewLazyRuntime(BackendEmulator, EnableInstanceAutoConfigOnly())
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			t.Errorf("failed to close lazy runtime: %v", err)
+		}
+	}()
+
+	t.Run("first call starts runtime", func(t *testing.T) {
+		clients := SetupClients(t, lazy,
+			WithRandomDatabaseID(),
+			WithSetupDDLs(ddls),
+		)
+		mustConsumeQuery(t, clients, "SELECT 1")
+	})
+
+	t.Run("second call reuses runtime", func(t *testing.T) {
+		clients := SetupClients(t, lazy,
+			WithRandomDatabaseID(),
+			WithSetupDDLs(ddls),
+		)
+		mustConsumeQuery(t, clients, "SELECT 1")
+	})
+}
+
+func TestLazyRuntimeEmulatorWithOpenClients(t *testing.T) {
+	lazy := NewLazyRuntime(BackendEmulator, EnableInstanceAutoConfigOnly())
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			t.Errorf("failed to close lazy runtime: %v", err)
+		}
+	}()
+
+	clients, err := OpenClients(t.Context(), lazy,
+		WithRandomDatabaseID(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := clients.Close(); err != nil {
+			t.Errorf("failed to close clients: %v", err)
+		}
+	}()
+
+	mustConsumeQuery(t, clients, "SELECT 1")
+}
+
+func TestLazyRuntimeEmulatorCanReplaceDirectEmulatorUseCases(t *testing.T) {
+	lazy := NewLazyRuntime(BackendEmulator, EnableInstanceAutoConfigOnly())
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			t.Errorf("failed to close lazy runtime: %v", err)
+		}
+	}()
+
+	runtime := lazy.Setup(t)
+	if runtime.URI() == "" {
+		t.Fatal("URI() is empty")
+	}
+	if opts := runtime.ClientOptions(); len(opts) != 4 {
+		t.Fatalf("ClientOptions() returned %d options, want 4", len(opts))
+	}
+
+	emu, ok := runtime.(*Emulator)
+	if !ok {
+		t.Fatalf("Setup() returned %T, want *Emulator for BackendEmulator", runtime)
+	}
+	if emu.Container() == nil {
+		t.Fatal("Container() is nil")
+	}
+
+	clients := SetupClients(t, runtime,
+		WithRandomDatabaseID(),
+	)
+	mustConsumeQuery(t, clients, "SELECT 1")
+}
+
+func TestLazyRuntimeConcurrentGet(t *testing.T) {
+	lazy := NewLazyRuntime(BackendEmulator, EnableInstanceAutoConfigOnly())
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			t.Errorf("failed to close lazy runtime: %v", err)
+		}
+	}()
+
+	const goroutines = 10
+	runtimes := make([]Runtime, goroutines)
+	errs := make([]error, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			runtimes[i], errs[i] = lazy.Get(t.Context())
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range goroutines {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d: Get() failed: %v", i, errs[i])
+		}
+		if runtimes[i] != runtimes[0] {
+			t.Errorf("goroutine %d: Get() returned different instance", i)
+		}
+	}
+}
+
+func TestLazyRuntimeGetReturnsSameInstance(t *testing.T) {
+	lazy := NewLazyRuntime(BackendEmulator, EnableInstanceAutoConfigOnly())
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			t.Errorf("failed to close lazy runtime: %v", err)
+		}
+	}()
+
+	ctx := t.Context()
+	runtime1, err := lazy.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime2, err := lazy.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime1 != runtime2 {
+		t.Error("Get() returned different instances")
+	}
+}
+
+func TestLazyRuntimeCloseWithoutStart(t *testing.T) {
+	lazy := NewLazyRuntime(BackendEmulator, EnableInstanceAutoConfigOnly())
+	if err := lazy.Close(); err != nil {
+		t.Fatalf("Close() on unused LazyRuntime should be no-op, got: %v", err)
+	}
+}
+
+func TestLazyRuntimeGetAfterClose(t *testing.T) {
+	lazy := NewLazyRuntime(BackendEmulator, EnableInstanceAutoConfigOnly())
 	if err := lazy.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/testing.go
+++ b/testing.go
@@ -40,6 +40,26 @@ func (e *Emulator) TestMain(m *testing.M) {
 	runTestMain(m, e.Close)
 }
 
+// TestMain runs m.Run(), closes the lazy runtime, and calls os.Exit with the
+// appropriate code. A close failure is logged and causes a non-zero exit code.
+// If the runtime was never started, Close is a no-op.
+//
+// Because TestMain calls os.Exit, it must be the last statement in your
+// TestMain function. If you need additional cleanup, refer to the
+// source of this method and write the logic manually.
+//
+// Usage in TestMain:
+//
+//	var lazy = spanemuboost.NewLazyRuntime(
+//	    spanemuboost.BackendEmulator,
+//	    spanemuboost.EnableInstanceAutoConfigOnly(),
+//	)
+//
+//	func TestMain(m *testing.M) { lazy.TestMain(m) }
+func (lr *LazyRuntime) TestMain(m *testing.M) {
+	runTestMain(m, lr.Close)
+}
+
 // TestMain runs m.Run(), closes the lazy emulator, and calls os.Exit with the
 // appropriate code. A close failure is logged and causes a non-zero exit code.
 // If the emulator was never started, Close is a no-op.
@@ -57,18 +77,31 @@ func (le *LazyEmulator) TestMain(m *testing.M) {
 	runTestMain(m, le.Close)
 }
 
+func setupLazy[T any](tb testing.TB, get func(context.Context) (T, error)) T {
+	tb.Helper()
+	value, err := get(tb.Context())
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return value
+}
+
+// Setup starts the selected backend on first call (thread-safe via [sync.Once])
+// and returns the cached [Runtime] on subsequent calls.
+// It calls [testing.TB.Fatal] if startup fails.
+// For use with [SetupClients] or [OpenClients], you can pass [*LazyRuntime] directly
+// without calling Setup.
+func (lr *LazyRuntime) Setup(tb testing.TB) Runtime {
+	return setupLazy(tb, lr.Get)
+}
+
 // Setup starts the emulator on first call (thread-safe via [sync.Once]) and
 // returns the cached [*Emulator] on subsequent calls.
 // It calls [testing.TB.Fatal] if startup fails.
 // For use with [SetupClients] or [OpenClients], you can pass [*LazyEmulator] directly
 // without calling Setup.
 func (le *LazyEmulator) Setup(tb testing.TB) *Emulator {
-	tb.Helper()
-	emu, err := le.Get(tb.Context())
-	if err != nil {
-		tb.Fatal(err)
-	}
-	return emu
+	return setupLazy(tb, le.Get)
 }
 
 func setupWithCleanup[T interface{ Close() error }](tb testing.TB, start func(context.Context) (T, error), closeTarget string) T {
@@ -121,12 +154,12 @@ func SetupEmulatorWithClients(tb testing.TB, options ...Option) *Env {
 
 // SetupClients opens Spanner clients against an existing runtime and registers
 // cleanup via [testing.TB.Cleanup]. It calls [testing.TB.Fatal] on setup error.
-// The runtime parameter accepts [*Emulator], [*LazyEmulator], and the [Runtime]
-// returned by [Run] or [Setup].
-// When a [*LazyEmulator] is passed, the emulator is started automatically on first use.
+// The runtime parameter accepts [*Emulator], [*LazyRuntime], [*LazyEmulator],
+// and the [Runtime] returned by [Run] or [Setup].
+// When a lazy runtime is passed, it is started automatically on first use.
 // The parameter type is intentionally limited to package-provided runtime values
-// so callers can use [*LazyEmulator] without adding another startup method to
-// the public [Runtime] interface.
+// so callers can use lazy runtime handles without adding another startup method
+// to the public [Runtime] interface.
 // Options inherit the runtime's projectID, instanceID, and databaseID.
 // Use [OpenClients] if you need a [context.Context] or are not in a test.
 func SetupClients(tb testing.TB, runtime abstractRuntime, options ...Option) *Clients {


### PR DESCRIPTION
## Summary
- add backend-neutral `LazyRuntime` support and use it throughout docs, examples, and tests
- commonize lazy runtime state and setup helpers shared with `LazyEmulator`
- harden lazy startup failure handling with regression tests and file follow-up issues for out-of-scope review findings

## Validation
- `TESTCONTAINERS_RYUK_DISABLED=true go test -race ./...`
- `golangci-lint run`
- `git diff --check`

## Follow-ups filed
- #28 rollback leaked schema resources on partial `OpenClients` failure
- #29 harden `Close` semantics across env/client types
- #30 run the full gated Omni smoke suite in CI