### PR TITLE
Roll back OpenClients resources on failure

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"slices"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/admin/database/apiv1"
@@ -26,6 +27,8 @@ type createdSchemaResources struct {
 	instance bool
 	database bool
 }
+
+const rollbackTimeout = 30 * time.Second
 
 func newEmulator(ctx context.Context, opts *emulatorOptions) (container *tcspanner.Container, teardown func(), err error) {
 	containerCustomizers := []testcontainers.ContainerCustomizer{
@@ -296,11 +299,11 @@ func bootstrapAndCreateClientsWithOptions(ctx context.Context, uri string, opts 
 	)
 	defer func() {
 		if retErr != nil {
-			if err := rollbackCreatedResources(instanceCli, dbCli, opts, createdResources); err != nil {
-				retErr = errors.Join(retErr, err)
-			}
 			if client != nil {
 				client.Close()
+			}
+			if err := rollbackCreatedResources(instanceCli, dbCli, opts, createdResources); err != nil {
+				retErr = errors.Join(retErr, err)
 			}
 			if dbCli != nil {
 				logCloseError("close database admin client", dbCli.Close())
@@ -350,9 +353,15 @@ func bootstrapAndCreateClientsWithOptions(ctx context.Context, uri string, opts 
 }
 
 func rollbackCreatedResources(instanceCli *instance.InstanceAdminClient, dbCli *database.DatabaseAdminClient, opts *emulatorOptions, resources createdSchemaResources) error {
-	ctx := context.Background()
+	// Rollback must still run if the setup context timed out or was canceled, but
+	// it should remain bounded so OpenClients failure handling cannot hang forever.
+	ctx, cancel := context.WithTimeout(context.Background(), rollbackTimeout)
+	defer cancel()
 
 	if resources.instance {
+		if instanceCli == nil {
+			return fmt.Errorf("rollback delete instance %s: instance admin client is nil", opts.InstancePath())
+		}
 		err := instanceCli.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{Name: opts.InstancePath()})
 		if err != nil {
 			return fmt.Errorf("rollback delete instance %s: %w", opts.InstancePath(), err)
@@ -361,12 +370,21 @@ func rollbackCreatedResources(instanceCli *instance.InstanceAdminClient, dbCli *
 	}
 
 	if resources.database {
+		if dbCli == nil {
+			return fmt.Errorf("rollback drop database %s: database admin client is nil", opts.DatabasePath())
+		}
 		err := dbCli.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: opts.DatabasePath()})
 		if err != nil {
 			return fmt.Errorf("rollback drop database %s: %w", opts.DatabasePath(), err)
 		}
 	}
 	return nil
+}
+
+func logCloseError(action string, err error) {
+	if err != nil {
+		log.Printf("spanemuboost: failed to %s: %v", action, err)
+	}
 }
 
 func newClients(ctx context.Context, emulator *tcspanner.Container, opts *emulatorOptions) (clients *Clients, teardown func(), err error) {

--- a/internal.go
+++ b/internal.go
@@ -2,6 +2,7 @@ package spanemuboost
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"slices"
@@ -20,6 +21,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+type createdSchemaResources struct {
+	instance bool
+	database bool
+}
 
 func newEmulator(ctx context.Context, opts *emulatorOptions) (container *tcspanner.Container, teardown func(), err error) {
 	containerCustomizers := []testcontainers.ContainerCustomizer{
@@ -113,22 +119,28 @@ func updateDDLs(ctx context.Context, opts *emulatorOptions, dbCli *database.Data
 }
 
 // bootstrapInstance creates the instance if auto-config is enabled.
-func bootstrapInstance(ctx context.Context, opts *emulatorOptions, instanceCli *instance.InstanceAdminClient) error {
+func bootstrapInstance(ctx context.Context, opts *emulatorOptions, instanceCli *instance.InstanceAdminClient) (bool, error) {
 	if opts.disableCreateInstance {
-		return nil
+		return false, nil
 	}
-	return createInstance(ctx, opts, instanceCli)
+	if err := createInstance(ctx, opts, instanceCli); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // bootstrapDatabase creates the database (with DDLs) or applies DDLs to an existing database.
-func bootstrapDatabase(ctx context.Context, opts *emulatorOptions, dbCli *database.DatabaseAdminClient) error {
+func bootstrapDatabase(ctx context.Context, opts *emulatorOptions, dbCli *database.DatabaseAdminClient) (bool, error) {
 	if !opts.disableCreateDatabase {
-		return createDatabase(ctx, opts, dbCli)
+		if err := createDatabase(ctx, opts, dbCli); err != nil {
+			return false, err
+		}
+		return true, nil
 	}
 	if len(opts.setupDDLs) > 0 {
-		return updateDDLs(ctx, opts, dbCli)
+		return false, updateDDLs(ctx, opts, dbCli)
 	}
-	return nil
+	return false, nil
 }
 
 func bootstrap(ctx context.Context, opts *emulatorOptions, clientOpts ...option.ClientOption) error {
@@ -143,7 +155,7 @@ func bootstrap(ctx context.Context, opts *emulatorOptions, clientOpts ...option.
 			}
 		}()
 
-		if err := createInstance(ctx, opts, instanceCli); err != nil {
+		if _, err := bootstrapInstance(ctx, opts, instanceCli); err != nil {
 			return err
 		}
 	}
@@ -159,7 +171,7 @@ func bootstrap(ctx context.Context, opts *emulatorOptions, clientOpts ...option.
 			}
 		}()
 
-		if err := bootstrapDatabase(ctx, opts, dbCli); err != nil {
+		if _, err := bootstrapDatabase(ctx, opts, dbCli); err != nil {
 			return err
 		}
 	}
@@ -185,7 +197,7 @@ func bootstrapWithManagedClientConfig(ctx context.Context, opts *emulatorOptions
 			}
 		}()
 
-		if err := bootstrapInstance(ctx, opts, instanceCli); err != nil {
+		if _, err := bootstrapInstance(ctx, opts, instanceCli); err != nil {
 			return err
 		}
 	}
@@ -201,7 +213,7 @@ func bootstrapWithManagedClientConfig(ctx context.Context, opts *emulatorOptions
 			}
 		}()
 
-		if err := bootstrapDatabase(ctx, opts, dbCli); err != nil {
+		if _, err := bootstrapDatabase(ctx, opts, dbCli); err != nil {
 			return err
 		}
 	}
@@ -277,43 +289,45 @@ func bootstrapAndCreateClientsWithOptions(ctx context.Context, uri string, opts 
 	if err != nil {
 		return nil, err
 	}
+	var (
+		dbCli             *database.DatabaseAdminClient
+		client            *spanner.Client
+		createdResources  createdSchemaResources
+	)
 	defer func() {
 		if retErr != nil {
-			if err := instanceCli.Close(); err != nil {
-				log.Printf("failed to close instance admin client: %v", err)
+			if err := rollbackCreatedResources(instanceCli, dbCli, opts, createdResources); err != nil {
+				retErr = errors.Join(retErr, err)
 			}
+			if client != nil {
+				client.Close()
+			}
+			if dbCli != nil {
+				logCloseError("close database admin client", dbCli.Close())
+			}
+			logCloseError("close instance admin client", instanceCli.Close())
 		}
 	}()
 
-	if err := bootstrapInstance(ctx, opts, instanceCli); err != nil {
-		return nil, err
-	}
-
-	dbCli, err := database.NewDatabaseAdminClient(ctx, clientOpts...)
+	createdResources.instance, err = bootstrapInstance(ctx, opts, instanceCli)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if retErr != nil {
-			if err := dbCli.Close(); err != nil {
-				log.Printf("failed to close database admin client: %v", err)
-			}
-		}
-	}()
 
-	if err := bootstrapDatabase(ctx, opts, dbCli); err != nil {
-		return nil, err
-	}
-
-	client, err := spanner.NewClientWithConfig(ctx, opts.DatabasePath(), *opts.clientConfig, slices.Concat(clientOpts, opts.clientOptionsForClient)...)
+	dbCli, err = database.NewDatabaseAdminClient(ctx, clientOpts...)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if retErr != nil {
-			client.Close()
-		}
-	}()
+
+	createdResources.database, err = bootstrapDatabase(ctx, opts, dbCli)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err = spanner.NewClientWithConfig(ctx, opts.DatabasePath(), *opts.clientConfig, slices.Concat(clientOpts, opts.clientOptionsForClient)...)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(opts.setupDMLs) > 0 {
 		if err := executeDMLsWithClient(ctx, opts, client); err != nil {
@@ -333,6 +347,26 @@ func bootstrapAndCreateClientsWithOptions(ctx context.Context, uri string, opts 
 		dropDatabase:   opts.shouldDropDatabase(),
 		dropInstance:   opts.shouldDropInstance(),
 	}, nil
+}
+
+func rollbackCreatedResources(instanceCli *instance.InstanceAdminClient, dbCli *database.DatabaseAdminClient, opts *emulatorOptions, resources createdSchemaResources) error {
+	ctx := context.Background()
+
+	if resources.instance {
+		err := instanceCli.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{Name: opts.InstancePath()})
+		if err != nil {
+			return fmt.Errorf("rollback delete instance %s: %w", opts.InstancePath(), err)
+		}
+		return nil
+	}
+
+	if resources.database {
+		err := dbCli.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: opts.DatabasePath()})
+		if err != nil {
+			return fmt.Errorf("rollback drop database %s: %w", opts.DatabasePath(), err)
+		}
+	}
+	return nil
 }
 
 func newClients(ctx context.Context, emulator *tcspanner.Container, opts *emulatorOptions) (clients *Clients, teardown func(), err error) {

--- a/internal.go
+++ b/internal.go
@@ -293,9 +293,9 @@ func bootstrapAndCreateClientsWithOptions(ctx context.Context, uri string, opts 
 		return nil, err
 	}
 	var (
-		dbCli             *database.DatabaseAdminClient
-		client            *spanner.Client
-		createdResources  createdSchemaResources
+		dbCli            *database.DatabaseAdminClient
+		client           *spanner.Client
+		createdResources createdSchemaResources
 	)
 	defer func() {
 		if retErr != nil {
@@ -360,20 +360,8 @@ func rollbackCreatedResources(instanceCli *instance.InstanceAdminClient, dbCli *
 	var errs []error
 
 	if resources.instance {
-		// DeleteInstance would also remove the database, but rollback is best-effort:
-		// dropping the database first still cleans up part of the leaked state if
-		// instance deletion later fails, while a successful instance delete still
-		// removes any remaining child resources.
-		if resources.database {
-			if dbCli == nil {
-				errs = append(errs, fmt.Errorf("rollback drop database %s: database admin client is nil", opts.DatabasePath()))
-			} else {
-				err := dbCli.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: opts.DatabasePath()})
-				if err != nil {
-					errs = append(errs, fmt.Errorf("rollback drop database %s: %w", opts.DatabasePath(), err))
-				}
-			}
-		}
+		// DeleteInstance removes child databases as well, so rollback avoids an
+		// extra DropDatabase call when the whole instance is being removed.
 		if instanceCli == nil {
 			errs = append(errs, fmt.Errorf("rollback delete instance %s: instance admin client is nil", opts.InstancePath()))
 		} else {

--- a/internal.go
+++ b/internal.go
@@ -360,8 +360,10 @@ func rollbackCreatedResources(instanceCli *instance.InstanceAdminClient, dbCli *
 	var errs []error
 
 	if resources.instance {
-		// If both resources were created, drop the database first so rollback still
-		// makes progress even when instance deletion later fails.
+		// DeleteInstance would also remove the database, but rollback is best-effort:
+		// dropping the database first still cleans up part of the leaked state if
+		// instance deletion later fails, while a successful instance delete still
+		// removes any remaining child resources.
 		if resources.database {
 			if dbCli == nil {
 				errs = append(errs, fmt.Errorf("rollback drop database %s: database admin client is nil", opts.DatabasePath()))

--- a/internal.go
+++ b/internal.go
@@ -20,7 +20,9 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/option/internaloption"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
 
 type createdSchemaResources struct {
@@ -360,17 +362,35 @@ func rollbackCreatedResources(instanceCli *instance.InstanceAdminClient, dbCli *
 	var errs []error
 
 	if resources.instance {
-		// DeleteInstance removes child databases on success. Rollback intentionally
-		// does not follow a failed DeleteInstance with DropDatabase, because the
-		// server-side outcome of the delete attempt may already be in flight and a
-		// second cleanup call would add redundant teardown work against the same
-		// hierarchy.
+		// DeleteInstance removes child databases on success, so only fall back to
+		// DropDatabase when instance cleanup could not run or when a follow-up
+		// GetInstance confirms the instance still exists after the delete error.
+		dropDatabase := false
 		if instanceCli == nil {
 			errs = append(errs, fmt.Errorf("rollback delete instance %s: instance admin client is nil", opts.InstancePath()))
+			dropDatabase = resources.database
 		} else {
 			err := instanceCli.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{Name: opts.InstancePath()})
 			if err != nil {
 				errs = append(errs, fmt.Errorf("rollback delete instance %s: %w", opts.InstancePath(), err))
+				if resources.database {
+					exists, existsErr := instanceStillExists(ctx, instanceCli, opts.InstancePath())
+					if existsErr != nil {
+						errs = append(errs, fmt.Errorf("rollback get instance %s: %w", opts.InstancePath(), existsErr))
+					} else if exists {
+						dropDatabase = true
+					}
+				}
+			}
+		}
+		if dropDatabase {
+			if dbCli == nil {
+				errs = append(errs, fmt.Errorf("rollback drop database %s: database admin client is nil", opts.DatabasePath()))
+			} else {
+				err := dbCli.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: opts.DatabasePath()})
+				if err != nil {
+					errs = append(errs, fmt.Errorf("rollback drop database %s: %w", opts.DatabasePath(), err))
+				}
 			}
 		}
 		return errors.Join(errs...)
@@ -387,6 +407,17 @@ func rollbackCreatedResources(instanceCli *instance.InstanceAdminClient, dbCli *
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func instanceStillExists(ctx context.Context, instanceCli *instance.InstanceAdminClient, instancePath string) (bool, error) {
+	_, err := instanceCli.GetInstance(ctx, &instancepb.GetInstanceRequest{Name: instancePath})
+	if err == nil {
+		return true, nil
+	}
+	if status.Code(err) == codes.NotFound {
+		return false, nil
+	}
+	return false, err
 }
 
 func logCloseError(action string, err error) {

--- a/internal.go
+++ b/internal.go
@@ -360,28 +360,17 @@ func rollbackCreatedResources(instanceCli *instance.InstanceAdminClient, dbCli *
 	var errs []error
 
 	if resources.instance {
-		// DeleteInstance removes child databases on success, so rollback avoids an
-		// extra DropDatabase call in the common case. If instance cleanup itself
-		// fails, still try DropDatabase so partial rollback can make progress.
-		instanceCleanupFailed := false
+		// DeleteInstance removes child databases on success. Rollback intentionally
+		// does not follow a failed DeleteInstance with DropDatabase, because the
+		// server-side outcome of the delete attempt may already be in flight and a
+		// second cleanup call would add redundant teardown work against the same
+		// hierarchy.
 		if instanceCli == nil {
 			errs = append(errs, fmt.Errorf("rollback delete instance %s: instance admin client is nil", opts.InstancePath()))
-			instanceCleanupFailed = true
 		} else {
 			err := instanceCli.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{Name: opts.InstancePath()})
 			if err != nil {
 				errs = append(errs, fmt.Errorf("rollback delete instance %s: %w", opts.InstancePath(), err))
-				instanceCleanupFailed = true
-			}
-		}
-		if instanceCleanupFailed && resources.database {
-			if dbCli == nil {
-				errs = append(errs, fmt.Errorf("rollback drop database %s: database admin client is nil", opts.DatabasePath()))
-			} else {
-				err := dbCli.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: opts.DatabasePath()})
-				if err != nil {
-					errs = append(errs, fmt.Errorf("rollback drop database %s: %w", opts.DatabasePath(), err))
-				}
 			}
 		}
 		return errors.Join(errs...)

--- a/internal.go
+++ b/internal.go
@@ -360,14 +360,28 @@ func rollbackCreatedResources(instanceCli *instance.InstanceAdminClient, dbCli *
 	var errs []error
 
 	if resources.instance {
-		// DeleteInstance removes child databases as well, so rollback avoids an
-		// extra DropDatabase call when the whole instance is being removed.
+		// DeleteInstance removes child databases on success, so rollback avoids an
+		// extra DropDatabase call in the common case. If instance cleanup itself
+		// fails, still try DropDatabase so partial rollback can make progress.
+		instanceCleanupFailed := false
 		if instanceCli == nil {
 			errs = append(errs, fmt.Errorf("rollback delete instance %s: instance admin client is nil", opts.InstancePath()))
+			instanceCleanupFailed = true
 		} else {
 			err := instanceCli.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{Name: opts.InstancePath()})
 			if err != nil {
 				errs = append(errs, fmt.Errorf("rollback delete instance %s: %w", opts.InstancePath(), err))
+				instanceCleanupFailed = true
+			}
+		}
+		if instanceCleanupFailed && resources.database {
+			if dbCli == nil {
+				errs = append(errs, fmt.Errorf("rollback drop database %s: database admin client is nil", opts.DatabasePath()))
+			} else {
+				err := dbCli.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: opts.DatabasePath()})
+				if err != nil {
+					errs = append(errs, fmt.Errorf("rollback drop database %s: %w", opts.DatabasePath(), err))
+				}
 			}
 		}
 		return errors.Join(errs...)

--- a/internal.go
+++ b/internal.go
@@ -357,28 +357,43 @@ func rollbackCreatedResources(instanceCli *instance.InstanceAdminClient, dbCli *
 	// it should remain bounded so OpenClients failure handling cannot hang forever.
 	ctx, cancel := context.WithTimeout(context.Background(), rollbackTimeout)
 	defer cancel()
+	var errs []error
 
 	if resources.instance {
+		// If both resources were created, drop the database first so rollback still
+		// makes progress even when instance deletion later fails.
+		if resources.database {
+			if dbCli == nil {
+				errs = append(errs, fmt.Errorf("rollback drop database %s: database admin client is nil", opts.DatabasePath()))
+			} else {
+				err := dbCli.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: opts.DatabasePath()})
+				if err != nil {
+					errs = append(errs, fmt.Errorf("rollback drop database %s: %w", opts.DatabasePath(), err))
+				}
+			}
+		}
 		if instanceCli == nil {
-			return fmt.Errorf("rollback delete instance %s: instance admin client is nil", opts.InstancePath())
+			errs = append(errs, fmt.Errorf("rollback delete instance %s: instance admin client is nil", opts.InstancePath()))
+		} else {
+			err := instanceCli.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{Name: opts.InstancePath()})
+			if err != nil {
+				errs = append(errs, fmt.Errorf("rollback delete instance %s: %w", opts.InstancePath(), err))
+			}
 		}
-		err := instanceCli.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{Name: opts.InstancePath()})
-		if err != nil {
-			return fmt.Errorf("rollback delete instance %s: %w", opts.InstancePath(), err)
-		}
-		return nil
+		return errors.Join(errs...)
 	}
 
 	if resources.database {
 		if dbCli == nil {
-			return fmt.Errorf("rollback drop database %s: database admin client is nil", opts.DatabasePath())
+			errs = append(errs, fmt.Errorf("rollback drop database %s: database admin client is nil", opts.DatabasePath()))
+			return errors.Join(errs...)
 		}
 		err := dbCli.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: opts.DatabasePath()})
 		if err != nil {
-			return fmt.Errorf("rollback drop database %s: %w", opts.DatabasePath(), err)
+			errs = append(errs, fmt.Errorf("rollback drop database %s: %w", opts.DatabasePath(), err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func logCloseError(action string, err error) {

--- a/omni.go
+++ b/omni.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"cloud.google.com/go/spanner"
@@ -228,12 +227,6 @@ func startOmni(ctx context.Context, opts *emulatorOptions) (*omniRuntime, error)
 		opts:      opts,
 		uri:       uri,
 	}, nil
-}
-
-func logCloseError(action string, err error) {
-	if err != nil {
-		log.Printf("spanemuboost: failed to %s: %v", action, err)
-	}
 }
 
 func wrapOmniBootstrapError(err error) error {

--- a/omni_test.go
+++ b/omni_test.go
@@ -473,6 +473,37 @@ func TestLazyRuntimeWithOmni(t *testing.T) {
 	}
 }
 
+func TestOpenOmniClientsRollsBackCreatedDatabaseOnFailure(t *testing.T) {
+	if os.Getenv("SPANEMUBOOST_ENABLE_OMNI_TESTS") == "" {
+		t.Skip("set SPANEMUBOOST_ENABLE_OMNI_TESTS=1 to run Spanner Omni tests")
+	}
+
+	omni := Setup(t, BackendOmni)
+	const dbID = "rollback-omni-dml-failure"
+
+	_, err := OpenClients(t.Context(), omni,
+		WithDatabaseID(dbID),
+		WithSetupDMLs([]spanner.Statement{
+			spanner.NewStatement("INSERT INTO missing_table (pk) VALUES ('x')"),
+		}),
+	)
+	if err == nil {
+		t.Fatal("first OpenClients() error = nil, want non-nil")
+	}
+
+	clients, err := OpenClients(t.Context(), omni, WithDatabaseID(dbID))
+	if err != nil {
+		t.Fatalf("second OpenClients() error = %v, want nil", err)
+	}
+	defer func() {
+		if err := clients.Close(); err != nil {
+			t.Errorf("failed to close clients: %v", err)
+		}
+	}()
+
+	mustConsumeQuery(t, clients, "SELECT 1")
+}
+
 func TestRunInvalidBackend(t *testing.T) {
 	_, err := Run(context.Background(), Backend("invalid"))
 	if err == nil {

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -1,6 +1,7 @@
 package spanemuboost
 
 import (
+	"strings"
 	"sync"
 	"testing"
 
@@ -530,6 +531,32 @@ func TestOpenClientsRollbackCreatedResourcesOnFailure(t *testing.T) {
 
 		mustConsumeQuery(t, clients, "SELECT 1")
 	})
+}
+
+func TestRollbackCreatedResourcesBestEffortErrors(t *testing.T) {
+	opts, err := applyOptions(
+		EnableAutoConfig(),
+		WithInstanceID("rollback-instance"),
+		WithDatabaseID("rollback-database"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = rollbackCreatedResources(nil, nil, opts, createdSchemaResources{
+		instance: true,
+		database: true,
+	})
+	if err == nil {
+		t.Fatal("rollbackCreatedResources() error = nil, want non-nil")
+	}
+
+	if !strings.Contains(err.Error(), "database admin client is nil") {
+		t.Fatalf("rollbackCreatedResources() error = %v, want database admin client failure", err)
+	}
+	if !strings.Contains(err.Error(), "instance admin client is nil") {
+		t.Fatalf("rollbackCreatedResources() error = %v, want instance admin client failure", err)
+	}
 }
 
 func TestEmulatorAccessors(t *testing.T) {

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -533,7 +533,7 @@ func TestOpenClientsRollbackCreatedResourcesOnFailure(t *testing.T) {
 	})
 }
 
-func TestRollbackCreatedResourcesFallsBackToDatabaseDropAfterInstanceFailure(t *testing.T) {
+func TestRollbackCreatedResourcesInstanceDeleteDoesNotAlsoDropDatabase(t *testing.T) {
 	opts, err := applyOptions(
 		EnableAutoConfig(),
 		WithInstanceID("rollback-instance"),
@@ -554,8 +554,8 @@ func TestRollbackCreatedResourcesFallsBackToDatabaseDropAfterInstanceFailure(t *
 	if !strings.Contains(err.Error(), "instance admin client is nil") {
 		t.Fatalf("rollbackCreatedResources() error = %v, want instance admin client failure", err)
 	}
-	if !strings.Contains(err.Error(), "database admin client is nil") {
-		t.Fatalf("rollbackCreatedResources() error = %v, want fallback database rollback failure", err)
+	if strings.Contains(err.Error(), "database admin client is nil") {
+		t.Fatalf("rollbackCreatedResources() error = %v, want only instance rollback failure", err)
 	}
 }
 

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -533,7 +533,7 @@ func TestOpenClientsRollbackCreatedResourcesOnFailure(t *testing.T) {
 	})
 }
 
-func TestRollbackCreatedResourcesBestEffortErrors(t *testing.T) {
+func TestRollbackCreatedResourcesInstanceSkipsDatabaseDrop(t *testing.T) {
 	opts, err := applyOptions(
 		EnableAutoConfig(),
 		WithInstanceID("rollback-instance"),
@@ -551,11 +551,11 @@ func TestRollbackCreatedResourcesBestEffortErrors(t *testing.T) {
 		t.Fatal("rollbackCreatedResources() error = nil, want non-nil")
 	}
 
-	if !strings.Contains(err.Error(), "database admin client is nil") {
-		t.Fatalf("rollbackCreatedResources() error = %v, want database admin client failure", err)
-	}
 	if !strings.Contains(err.Error(), "instance admin client is nil") {
 		t.Fatalf("rollbackCreatedResources() error = %v, want instance admin client failure", err)
+	}
+	if strings.Contains(err.Error(), "database admin client is nil") {
+		t.Fatalf("rollbackCreatedResources() error = %v, want instance-only rollback failure", err)
 	}
 }
 

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -465,6 +465,73 @@ func TestSchemaTeardown(t *testing.T) {
 	})
 }
 
+func TestOpenClientsRollbackCreatedResourcesOnFailure(t *testing.T) {
+	t.Run("created database is rolled back after setup failure", func(t *testing.T) {
+		emu := SetupEmulator(t, EnableInstanceAutoConfigOnly())
+		const dbID = "rollback-dml-failure"
+
+		_, err := OpenClients(t.Context(), emu,
+			WithDatabaseID(dbID),
+			WithSetupDMLs([]spanner.Statement{
+				spanner.NewStatement("INSERT INTO missing_table (pk) VALUES ('x')"),
+			}),
+		)
+		if err == nil {
+			t.Fatal("first OpenClients() error = nil, want non-nil")
+		}
+
+		clients, err := OpenClients(t.Context(), emu,
+			WithDatabaseID(dbID),
+		)
+		if err != nil {
+			t.Fatalf("second OpenClients() error = %v, want nil", err)
+		}
+		defer func() {
+			if err := clients.Close(); err != nil {
+				t.Errorf("failed to close clients: %v", err)
+			}
+		}()
+
+		mustConsumeQuery(t, clients, "SELECT 1")
+	})
+
+	t.Run("created instance is rolled back after setup failure", func(t *testing.T) {
+		emu := SetupEmulator(t)
+		const (
+			instanceID = "rollback-instance-failure"
+			databaseID = "rollback-instance-db"
+		)
+
+		_, err := OpenClients(t.Context(), emu,
+			EnableAutoConfig(),
+			WithInstanceID(instanceID),
+			WithDatabaseID(databaseID),
+			WithSetupDMLs([]spanner.Statement{
+				spanner.NewStatement("INSERT INTO missing_table (pk) VALUES ('x')"),
+			}),
+		)
+		if err == nil {
+			t.Fatal("first OpenClients() error = nil, want non-nil")
+		}
+
+		clients, err := OpenClients(t.Context(), emu,
+			EnableAutoConfig(),
+			WithInstanceID(instanceID),
+			WithDatabaseID(databaseID),
+		)
+		if err != nil {
+			t.Fatalf("second OpenClients() error = %v, want nil", err)
+		}
+		defer func() {
+			if err := clients.Close(); err != nil {
+				t.Errorf("failed to close clients: %v", err)
+			}
+		}()
+
+		mustConsumeQuery(t, clients, "SELECT 1")
+	})
+}
+
 func TestEmulatorAccessors(t *testing.T) {
 	emu := SetupEmulator(t, DisableAutoConfig())
 

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -533,7 +533,7 @@ func TestOpenClientsRollbackCreatedResourcesOnFailure(t *testing.T) {
 	})
 }
 
-func TestRollbackCreatedResourcesInstanceSkipsDatabaseDrop(t *testing.T) {
+func TestRollbackCreatedResourcesFallsBackToDatabaseDropAfterInstanceFailure(t *testing.T) {
 	opts, err := applyOptions(
 		EnableAutoConfig(),
 		WithInstanceID("rollback-instance"),
@@ -554,8 +554,8 @@ func TestRollbackCreatedResourcesInstanceSkipsDatabaseDrop(t *testing.T) {
 	if !strings.Contains(err.Error(), "instance admin client is nil") {
 		t.Fatalf("rollbackCreatedResources() error = %v, want instance admin client failure", err)
 	}
-	if strings.Contains(err.Error(), "database admin client is nil") {
-		t.Fatalf("rollbackCreatedResources() error = %v, want instance-only rollback failure", err)
+	if !strings.Contains(err.Error(), "database admin client is nil") {
+		t.Fatalf("rollbackCreatedResources() error = %v, want fallback database rollback failure", err)
 	}
 }
 

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -533,7 +533,7 @@ func TestOpenClientsRollbackCreatedResourcesOnFailure(t *testing.T) {
 	})
 }
 
-func TestRollbackCreatedResourcesInstanceDeleteDoesNotAlsoDropDatabase(t *testing.T) {
+func TestRollbackCreatedResourcesFallsBackToDatabaseDropWhenInstanceDeleteCannotRun(t *testing.T) {
 	opts, err := applyOptions(
 		EnableAutoConfig(),
 		WithInstanceID("rollback-instance"),
@@ -554,8 +554,8 @@ func TestRollbackCreatedResourcesInstanceDeleteDoesNotAlsoDropDatabase(t *testin
 	if !strings.Contains(err.Error(), "instance admin client is nil") {
 		t.Fatalf("rollbackCreatedResources() error = %v, want instance admin client failure", err)
 	}
-	if strings.Contains(err.Error(), "database admin client is nil") {
-		t.Fatalf("rollbackCreatedResources() error = %v, want only instance rollback failure", err)
+	if !strings.Contains(err.Error(), "database admin client is nil") {
+		t.Fatalf("rollbackCreatedResources() error = %v, want fallback database rollback failure", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- roll back auto-created instance/database resources when `OpenClients` fails after creating schema state
- track whether bootstrap created an instance or database so rollback only deletes resources created by the failing call
- add emulator regression tests for both database-only and instance-plus-database failures, plus an Omni-gated regression test

Closes #28

## Validation
- `TESTCONTAINERS_RYUK_DISABLED=true go test -count=1 -run TestOpenClientsRollbackCreatedResourcesOnFailure ./...`
- `TESTCONTAINERS_RYUK_DISABLED=true go test -race ./...`
- `golangci-lint run`
- `git diff --check`