### PR TITLE
ci: run the full gated Omni smoke suite

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,4 +40,5 @@ jobs:
       - name: Run Omni smoke test
         env:
           SPANEMUBOOST_ENABLE_OMNI_TESTS: "1"
-        run: go test -v -race -count=1 -shuffle=on -run '^TestOpenOmniClientsReuseDefaultDatabase$' ./...
+        # Limit the smoke job to the env-gated Omni integration coverage in omni_test.go.
+        run: go test -v -race -count=1 -shuffle=on -run '^Test(RunOmni(WithClients)?|OpenOmniClients(ReuseDefaultDatabase|AllowDatabaseOverride)?|SetupClientsWithOmni|LazyRuntimeWithOmni)$' ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,4 @@ jobs:
           go-version-file: go.mod
 
       - name: Run Omni smoke test
-        env:
-          SPANEMUBOOST_ENABLE_OMNI_TESTS: "1"
-        # Limit the smoke job to the env-gated Omni integration coverage in omni_test.go.
-        run: go test -v -race -count=1 -shuffle=on -run '^Test(RunOmni(WithClients)?|OpenOmniClients(ReuseDefaultDatabase|AllowDatabaseOverride)?|SetupClientsWithOmni|LazyRuntimeWithOmni)$' ./...
+        run: make omni-smoke

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,5 +37,5 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Run Omni smoke test
+      - name: Run Omni smoke tests
         run: make omni-smoke

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 .PHONY: test lint omni-smoke
 
 # Keep this as an explicit test-name list rather than a compact grouped regex so
-# CI selection stays easy to audit when Omni smoke coverage changes.
-OMNI_SMOKE_TEST_PATTERN = ^(TestRunOmni|TestRunOmniWithClients|TestOpenOmniClients|TestOpenOmniClientsReuseDefaultDatabase|TestOpenOmniClientsAllowDatabaseOverride|TestSetupClientsWithOmni|TestLazyRuntimeWithOmni)$$
+# CI selection stays easy to audit when Omni smoke coverage changes. Match either
+# the top-level test name or one of its subtests.
+OMNI_SMOKE_TEST_PATTERN = ^(TestRunOmni|TestRunOmniWithClients|TestOpenOmniClients|TestOpenOmniClientsReuseDefaultDatabase|TestOpenOmniClientsAllowDatabaseOverride|TestSetupClientsWithOmni|TestLazyRuntimeWithOmni)($$|/)
 
 test:
 	go test -v ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
+.PHONY: test lint omni-smoke
+
+# Keep this as an explicit test-name list rather than a compact grouped regex so
+# CI selection stays easy to audit when Omni smoke coverage changes.
+OMNI_SMOKE_TEST_PATTERN = ^(TestRunOmni|TestRunOmniWithClients|TestOpenOmniClients|TestOpenOmniClientsReuseDefaultDatabase|TestOpenOmniClientsAllowDatabaseOverride|TestSetupClientsWithOmni|TestLazyRuntimeWithOmni)$$
+
 test:
 	go test -v ./...
 lint:
 	golangci-lint run
+omni-smoke:
+	SPANEMUBOOST_ENABLE_OMNI_TESTS=1 go test -v -race -count=1 -shuffle=on -run '$(OMNI_SMOKE_TEST_PATTERN)' ./...


### PR DESCRIPTION
Closes #29

## Summary
- widen the `omni-smoke` workflow filter from one test to the full env-gated Omni integration smoke suite
- keep the job focused on Omni runtime/client bootstrap coverage instead of broad unit coverage
- document that the regex intentionally targets the gated integration tests in `omni_test.go`

## Validation
- `golangci-lint run`
- `go test -list '^Test(RunOmni(WithClients)?|OpenOmniClients(ReuseDefaultDatabase|AllowDatabaseOverride)?|SetupClientsWithOmni|LazyRuntimeWithOmni)$' ./...`\n- `go test -count=1 -run '^Test(RunOmni(WithClients)?|OpenOmniClients(ReuseDefaultDatabase|AllowDatabaseOverride)?|SetupClientsWithOmni|LazyRuntimeWithOmni)$' ./...`\n\n## Local limits\n- the full Omni integration environment is not available locally, so the targeted run above only verifies selection/compilation with the env-gated tests skipped\n- baseline `go test ./...` is currently blocked in this environment by Docker/testcontainers failing to find the `bridge` network for emulator-based tests