### PR TITLE
Harden close helper semantics

### DIFF
--- a/close.go
+++ b/close.go
@@ -22,6 +22,9 @@ func (s *closeState) close(fn func() error) error {
 	return s.err
 }
 
+// Exported value types keep *closeState rather than embedding sync.Once
+// directly so they preserve their previous comparability semantics and do not
+// expose a copylock field as part of the public struct layout.
 func ensureCloseState(slot **closeState) *closeState {
 	closeStateInitMu.Lock()
 	defer closeStateInitMu.Unlock()

--- a/close.go
+++ b/close.go
@@ -23,9 +23,6 @@ func (s *closeState) close(fn func() error) error {
 }
 
 func ensureCloseState(slot **closeState) *closeState {
-	if *slot != nil {
-		return *slot
-	}
 	closeStateInitMu.Lock()
 	defer closeStateInitMu.Unlock()
 	if *slot == nil {

--- a/close.go
+++ b/close.go
@@ -1,0 +1,25 @@
+package spanemuboost
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+const closeTimeout = 30 * time.Second
+
+type closeState struct {
+	once sync.Once
+	err  error
+}
+
+func (s *closeState) close(fn func() error) error {
+	s.once.Do(func() {
+		s.err = fn()
+	})
+	return s.err
+}
+
+func newCloseContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), closeTimeout)
+}

--- a/close.go
+++ b/close.go
@@ -13,11 +13,25 @@ type closeState struct {
 	err  error
 }
 
+var closeStateInitMu sync.Mutex
+
 func (s *closeState) close(fn func() error) error {
 	s.once.Do(func() {
 		s.err = fn()
 	})
 	return s.err
+}
+
+func ensureCloseState(slot **closeState) *closeState {
+	if *slot != nil {
+		return *slot
+	}
+	closeStateInitMu.Lock()
+	defer closeStateInitMu.Unlock()
+	if *slot == nil {
+		*slot = &closeState{}
+	}
+	return *slot
 }
 
 func newCloseContext() (context.Context, context.CancelFunc) {

--- a/close_test.go
+++ b/close_test.go
@@ -1,0 +1,50 @@
+package spanemuboost
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestCloseStateConcurrentCalls(t *testing.T) {
+	var (
+		state closeState
+		wg    sync.WaitGroup
+		errs  = make([]error, 2)
+	)
+
+	wantErr := errors.New("close failed")
+	started := make(chan struct{})
+	release := make(chan struct{})
+	calls := 0
+
+	closeFn := func() error {
+		calls++
+		close(started)
+		<-release
+		return wantErr
+	}
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		errs[0] = state.close(closeFn)
+	}()
+	<-started
+	go func() {
+		defer wg.Done()
+		errs[1] = state.close(closeFn)
+	}()
+
+	close(release)
+	wg.Wait()
+
+	if calls != 1 {
+		t.Fatalf("close calls = %d, want 1", calls)
+	}
+	for i, err := range errs {
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("errs[%d] = %v, want %v", i, err, wantErr)
+		}
+	}
+}

--- a/emulator.go
+++ b/emulator.go
@@ -14,8 +14,7 @@ type Emulator struct {
 	container *tcspanner.Container
 	opts      *emulatorOptions
 
-	closed   bool
-	closeErr error
+	closeState closeState
 }
 
 func (*Emulator) spanemuboostRuntime() {}
@@ -56,14 +55,14 @@ func (e *Emulator) Close() error {
 	if e == nil {
 		return nil
 	}
-	if e.closed {
-		return e.closeErr
-	}
-	e.closed = true
-	if e.container != nil {
-		e.closeErr = e.container.Terminate(context.Background())
-	}
-	return e.closeErr
+	return e.closeState.close(func() error {
+		if e.container == nil {
+			return nil
+		}
+		ctx, cancel := newCloseContext()
+		defer cancel()
+		return e.container.Terminate(ctx)
+	})
 }
 
 // Container returns the underlying [*tcspanner.Container] for direct access.
@@ -153,8 +152,7 @@ type Env struct {
 	*Clients
 	emulator *Emulator
 
-	closed   bool
-	closeErr error
+	closeState closeState
 }
 
 // Emulator returns the underlying [Emulator].
@@ -169,18 +167,14 @@ func (e *Env) Close() error {
 	if e == nil {
 		return nil
 	}
-	if e.closed {
-		return e.closeErr
-	}
-	e.closed = true
-
-	var errs []error
-	if e.Clients != nil {
-		errs = append(errs, e.Clients.Close())
-	}
-	if e.emulator != nil {
-		errs = append(errs, e.emulator.Close())
-	}
-	e.closeErr = errors.Join(errs...)
-	return e.closeErr
+	return e.closeState.close(func() error {
+		var errs []error
+		if e.Clients != nil {
+			errs = append(errs, e.Clients.Close())
+		}
+		if e.emulator != nil {
+			errs = append(errs, e.emulator.Close())
+		}
+		return errors.Join(errs...)
+	})
 }

--- a/emulator.go
+++ b/emulator.go
@@ -14,7 +14,7 @@ type Emulator struct {
 	container *tcspanner.Container
 	opts      *emulatorOptions
 
-	closeState closeState
+	closeState *closeState
 }
 
 func (*Emulator) spanemuboostRuntime() {}
@@ -55,7 +55,7 @@ func (e *Emulator) Close() error {
 	if e == nil {
 		return nil
 	}
-	return e.closeState.close(func() error {
+	return ensureCloseState(&e.closeState).close(func() error {
 		if e.container == nil {
 			return nil
 		}
@@ -152,7 +152,7 @@ type Env struct {
 	*Clients
 	emulator *Emulator
 
-	closeState closeState
+	closeState *closeState
 }
 
 // Emulator returns the underlying [Emulator].
@@ -167,7 +167,7 @@ func (e *Env) Close() error {
 	if e == nil {
 		return nil
 	}
-	return e.closeState.close(func() error {
+	return ensureCloseState(&e.closeState).close(func() error {
 		var errs []error
 		if e.Clients != nil {
 			errs = append(errs, e.Clients.Close())

--- a/emulator.go
+++ b/emulator.go
@@ -14,6 +14,7 @@ type Emulator struct {
 	container *tcspanner.Container
 	opts      *emulatorOptions
 
+	// Pointer-backed to keep exported Emulator comparable as a value.
 	closeState *closeState
 }
 
@@ -152,6 +153,7 @@ type Env struct {
 	*Clients
 	emulator *Emulator
 
+	// Pointer-backed to keep exported Env comparable as a value.
 	closeState *closeState
 }
 

--- a/emulator.go
+++ b/emulator.go
@@ -13,6 +13,9 @@ import (
 type Emulator struct {
 	container *tcspanner.Container
 	opts      *emulatorOptions
+
+	closed   bool
+	closeErr error
 }
 
 func (*Emulator) spanemuboostRuntime() {}
@@ -47,8 +50,20 @@ func (e *Emulator) ClientOptions() []option.ClientOption {
 }
 
 // Close terminates the emulator container.
+// Close is nil-safe and idempotent. After the first call, subsequent calls
+// return the result of that first call.
 func (e *Emulator) Close() error {
-	return e.container.Terminate(context.Background())
+	if e == nil {
+		return nil
+	}
+	if e.closed {
+		return e.closeErr
+	}
+	e.closed = true
+	if e.container != nil {
+		e.closeErr = e.container.Terminate(context.Background())
+	}
+	return e.closeErr
 }
 
 // Container returns the underlying [*tcspanner.Container] for direct access.
@@ -122,10 +137,13 @@ func (le *LazyEmulator) Get(ctx context.Context) (*Emulator, error) {
 }
 
 // Close terminates the emulator if it was started. No-op otherwise.
-// Close is idempotent — subsequent calls return the result of the first call.
+// Close is nil-safe and idempotent — subsequent calls return the result of the first call.
 // Close waits for any in-progress initialization to complete before checking.
 // If Close is called before any Get or Setup, the emulator will never be started.
 func (le *LazyEmulator) Close() error {
+	if le == nil {
+		return nil
+	}
 	return le.state.close()
 }
 
@@ -134,6 +152,9 @@ func (le *LazyEmulator) Close() error {
 type Env struct {
 	*Clients
 	emulator *Emulator
+
+	closed   bool
+	closeErr error
 }
 
 // Emulator returns the underlying [Emulator].
@@ -142,9 +163,24 @@ func (e *Env) Emulator() *Emulator {
 }
 
 // Close closes the clients and then terminates the emulator.
+// Close is nil-safe and idempotent. After the first call, subsequent calls
+// return the result of that first call.
 func (e *Env) Close() error {
-	return errors.Join(
-		e.Clients.Close(),
-		e.emulator.Close(),
-	)
+	if e == nil {
+		return nil
+	}
+	if e.closed {
+		return e.closeErr
+	}
+	e.closed = true
+
+	var errs []error
+	if e.Clients != nil {
+		errs = append(errs, e.Clients.Close())
+	}
+	if e.emulator != nil {
+		errs = append(errs, e.emulator.Close())
+	}
+	e.closeErr = errors.Join(errs...)
+	return e.closeErr
 }

--- a/lazy.go
+++ b/lazy.go
@@ -104,9 +104,12 @@ func (lr *LazyRuntime) Get(ctx context.Context) (Runtime, error) {
 }
 
 // Close terminates the runtime if it was started. No-op otherwise.
-// Close is idempotent — subsequent calls return the result of the first call.
+// Close is nil-safe and idempotent — subsequent calls return the result of the first call.
 // Close waits for any in-progress initialization to complete before checking.
 // If Close is called before any Get or Setup, the runtime will never be started.
 func (lr *LazyRuntime) Close() error {
+	if lr == nil {
+		return nil
+	}
 	return lr.state.close()
 }

--- a/lazy_test.go
+++ b/lazy_test.go
@@ -19,6 +19,18 @@ func TestLazyEmulatorCloseAfterFailedGet(t *testing.T) {
 	}
 }
 
+func TestLazyCloseNilReceivers(t *testing.T) {
+	var lazyRuntime *LazyRuntime
+	if err := lazyRuntime.Close(); err != nil {
+		t.Fatalf("(*LazyRuntime)(nil).Close() error = %v, want nil", err)
+	}
+
+	var lazyEmulator *LazyEmulator
+	if err := lazyEmulator.Close(); err != nil {
+		t.Fatalf("(*LazyEmulator)(nil).Close() error = %v, want nil", err)
+	}
+}
+
 func TestLazyRuntimeStateGetRepanicsAfterStartPanic(t *testing.T) {
 	var state lazyRuntimeState
 	const want = "boom"

--- a/omni.go
+++ b/omni.go
@@ -31,8 +31,7 @@ type omniRuntime struct {
 	opts      *emulatorOptions
 	uri       string
 
-	closed   bool
-	closeErr error
+	closeState closeState
 }
 
 func (*omniRuntime) spanemuboostRuntime() {}
@@ -83,14 +82,14 @@ func (o *omniRuntime) Close() error {
 	if o == nil {
 		return nil
 	}
-	if o.closed {
-		return o.closeErr
-	}
-	o.closed = true
-	if o.container != nil {
-		o.closeErr = o.container.Terminate(context.Background())
-	}
-	return o.closeErr
+	return o.closeState.close(func() error {
+		if o.container == nil {
+			return nil
+		}
+		ctx, cancel := newCloseContext()
+		defer cancel()
+		return o.container.Terminate(ctx)
+	})
 }
 
 // ProjectID returns the fixed project ID used by the single-server Omni deployment.

--- a/omni.go
+++ b/omni.go
@@ -30,6 +30,9 @@ type omniRuntime struct {
 	container testcontainers.Container
 	opts      *emulatorOptions
 	uri       string
+
+	closed   bool
+	closeErr error
 }
 
 func (*omniRuntime) spanemuboostRuntime() {}
@@ -77,7 +80,17 @@ func finalizeManagedOmniClientConfig(config *spanner.ClientConfig, disableBacken
 
 // Close terminates the Omni container.
 func (o *omniRuntime) Close() error {
-	return o.container.Terminate(context.Background())
+	if o == nil {
+		return nil
+	}
+	if o.closed {
+		return o.closeErr
+	}
+	o.closed = true
+	if o.container != nil {
+		o.closeErr = o.container.Terminate(context.Background())
+	}
+	return o.closeErr
 }
 
 // ProjectID returns the fixed project ID used by the single-server Omni deployment.

--- a/omni_test.go
+++ b/omni_test.go
@@ -20,6 +20,21 @@ func TestRecommendedOmniClientConfig(t *testing.T) {
 	}
 }
 
+func TestOmniRuntimeCloseZeroValue(t *testing.T) {
+	var nilRuntime *omniRuntime
+	if err := nilRuntime.Close(); err != nil {
+		t.Fatalf("nil Close() error = %v, want nil", err)
+	}
+
+	runtime := &omniRuntime{}
+	if err := runtime.Close(); err != nil {
+		t.Fatalf("first Close() error = %v, want nil", err)
+	}
+	if err := runtime.Close(); err != nil {
+		t.Fatalf("second Close() error = %v, want nil", err)
+	}
+}
+
 func TestRunOmniRejectsUnsupportedProjectOptions(t *testing.T) {
 	t.Run("custom project", func(t *testing.T) {
 		_, err := Run(context.Background(), BackendOmni, WithProjectID("custom"))

--- a/runtime.go
+++ b/runtime.go
@@ -125,6 +125,9 @@ func isNilRuntimeValue(runtime Runtime) bool {
 type RuntimeEnv struct {
 	*Clients
 	runtime Runtime
+
+	closed   bool
+	closeErr error
 }
 
 // Runtime returns the started runtime behind this environment.
@@ -133,10 +136,16 @@ func (e *RuntimeEnv) Runtime() Runtime {
 }
 
 // Close closes the clients and then terminates the runtime.
+// Close is nil-safe and idempotent. After the first call, subsequent calls
+// return the result of that first call.
 func (e *RuntimeEnv) Close() error {
 	if e == nil {
 		return nil
 	}
+	if e.closed {
+		return e.closeErr
+	}
+	e.closed = true
 
 	var errs []error
 	if e.Clients != nil {
@@ -145,7 +154,8 @@ func (e *RuntimeEnv) Close() error {
 	if e.runtime != nil {
 		errs = append(errs, e.runtime.Close())
 	}
-	return errors.Join(errs...)
+	e.closeErr = errors.Join(errs...)
+	return e.closeErr
 }
 
 // Run starts the selected backend and returns it as a backend-neutral runtime.

--- a/runtime.go
+++ b/runtime.go
@@ -126,7 +126,7 @@ type RuntimeEnv struct {
 	*Clients
 	runtime Runtime
 
-	closeState closeState
+	closeState *closeState
 }
 
 // Runtime returns the started runtime behind this environment.
@@ -141,7 +141,7 @@ func (e *RuntimeEnv) Close() error {
 	if e == nil {
 		return nil
 	}
-	return e.closeState.close(func() error {
+	return ensureCloseState(&e.closeState).close(func() error {
 		var errs []error
 		if e.Clients != nil {
 			errs = append(errs, e.Clients.Close())

--- a/runtime.go
+++ b/runtime.go
@@ -126,8 +126,7 @@ type RuntimeEnv struct {
 	*Clients
 	runtime Runtime
 
-	closed   bool
-	closeErr error
+	closeState closeState
 }
 
 // Runtime returns the started runtime behind this environment.
@@ -142,20 +141,16 @@ func (e *RuntimeEnv) Close() error {
 	if e == nil {
 		return nil
 	}
-	if e.closed {
-		return e.closeErr
-	}
-	e.closed = true
-
-	var errs []error
-	if e.Clients != nil {
-		errs = append(errs, e.Clients.Close())
-	}
-	if e.runtime != nil {
-		errs = append(errs, e.runtime.Close())
-	}
-	e.closeErr = errors.Join(errs...)
-	return e.closeErr
+	return e.closeState.close(func() error {
+		var errs []error
+		if e.Clients != nil {
+			errs = append(errs, e.Clients.Close())
+		}
+		if e.runtime != nil {
+			errs = append(errs, e.runtime.Close())
+		}
+		return errors.Join(errs...)
+	})
 }
 
 // Run starts the selected backend and returns it as a backend-neutral runtime.

--- a/runtime.go
+++ b/runtime.go
@@ -126,6 +126,7 @@ type RuntimeEnv struct {
 	*Clients
 	runtime Runtime
 
+	// Pointer-backed to keep exported RuntimeEnv comparable as a value.
 	closeState *closeState
 }
 

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -43,6 +43,9 @@ type Clients struct {
 
 	dropDatabase bool
 	dropInstance bool
+
+	closed   bool
+	closeErr error
 }
 
 func (c *Clients) ProjectPath() string  { return projectPath(c.ProjectID) }
@@ -68,31 +71,53 @@ func (c *Clients) URI() string {
 // the clients are closed. See [ForceSchemaTeardown] and [SkipSchemaTeardown].
 // [spanner.Client.Close] does not return an error, so only admin client and
 // resource cleanup errors are returned.
+// Close is nil-safe and idempotent. After the first call, subsequent calls
+// return the result of that first call.
 func (c *Clients) Close() error {
-	c.Client.Close()
+	if c == nil {
+		return nil
+	}
+	if c.closed {
+		return c.closeErr
+	}
+	c.closed = true
+
+	if c.Client != nil {
+		c.Client.Close()
+	}
 
 	var dropErrs []error
 	ctx := context.Background()
 	if c.dropInstance {
 		// Deleting the instance also removes all databases within it,
 		// so there is no need to drop the database separately.
-		if err := c.InstanceClient.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{
+		if c.InstanceClient == nil {
+			dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: instance admin client is nil", c.InstancePath()))
+		} else if err := c.InstanceClient.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{
 			Name: c.InstancePath(),
 		}); err != nil {
 			dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: %w", c.InstancePath(), err))
 		}
 	} else if c.dropDatabase {
-		if err := c.DatabaseClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
+		if c.DatabaseClient == nil {
+			dropErrs = append(dropErrs, fmt.Errorf("drop database %s: database admin client is nil", c.DatabasePath()))
+		} else if err := c.DatabaseClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
 			Database: c.DatabasePath(),
 		}); err != nil {
 			dropErrs = append(dropErrs, fmt.Errorf("drop database %s: %w", c.DatabasePath(), err))
 		}
 	}
 
-	return errors.Join(append(dropErrs,
-		c.DatabaseClient.Close(),
-		c.InstanceClient.Close(),
-	)...)
+	var errs []error
+	errs = append(errs, dropErrs...)
+	if c.DatabaseClient != nil {
+		errs = append(errs, c.DatabaseClient.Close())
+	}
+	if c.InstanceClient != nil {
+		errs = append(errs, c.InstanceClient.Close())
+	}
+	c.closeErr = errors.Join(errs...)
+	return c.closeErr
 }
 
 // RunEmulator starts a Cloud Spanner Emulator container and performs any

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -83,25 +83,27 @@ func (c *Clients) Close() error {
 		}
 
 		var dropErrs []error
-		ctx, cancel := newCloseContext()
-		defer cancel()
-		if c.dropInstance {
-			// Deleting the instance also removes all databases within it,
-			// so there is no need to drop the database separately.
-			if c.InstanceClient == nil {
-				dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: instance admin client is nil", c.InstancePath()))
-			} else if err := c.InstanceClient.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{
-				Name: c.InstancePath(),
-			}); err != nil {
-				dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: %w", c.InstancePath(), err))
-			}
-		} else if c.dropDatabase {
-			if c.DatabaseClient == nil {
-				dropErrs = append(dropErrs, fmt.Errorf("drop database %s: database admin client is nil", c.DatabasePath()))
-			} else if err := c.DatabaseClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
-				Database: c.DatabasePath(),
-			}); err != nil {
-				dropErrs = append(dropErrs, fmt.Errorf("drop database %s: %w", c.DatabasePath(), err))
+		if c.dropInstance || c.dropDatabase {
+			ctx, cancel := newCloseContext()
+			defer cancel()
+			if c.dropInstance {
+				// Deleting the instance also removes all databases within it,
+				// so there is no need to drop the database separately.
+				if c.InstanceClient == nil {
+					dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: instance admin client is nil", c.InstancePath()))
+				} else if err := c.InstanceClient.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{
+					Name: c.InstancePath(),
+				}); err != nil {
+					dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: %w", c.InstancePath(), err))
+				}
+			} else if c.dropDatabase {
+				if c.DatabaseClient == nil {
+					dropErrs = append(dropErrs, fmt.Errorf("drop database %s: database admin client is nil", c.DatabasePath()))
+				} else if err := c.DatabaseClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
+					Database: c.DatabasePath(),
+				}); err != nil {
+					dropErrs = append(dropErrs, fmt.Errorf("drop database %s: %w", c.DatabasePath(), err))
+				}
 			}
 		}
 

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -44,7 +44,7 @@ type Clients struct {
 	dropDatabase bool
 	dropInstance bool
 
-	closeState closeState
+	closeState *closeState
 }
 
 func (c *Clients) ProjectPath() string  { return projectPath(c.ProjectID) }
@@ -77,12 +77,12 @@ func (c *Clients) Close() error {
 	if c == nil {
 		return nil
 	}
-	return c.closeState.close(func() error {
+	return ensureCloseState(&c.closeState).close(func() error {
+		var errs []error
 		if c.Client != nil {
 			c.Client.Close()
 		}
 
-		var dropErrs []error
 		if c.dropInstance || c.dropDatabase {
 			ctx, cancel := newCloseContext()
 			defer cancel()
@@ -90,25 +90,23 @@ func (c *Clients) Close() error {
 				// Deleting the instance also removes all databases within it,
 				// so there is no need to drop the database separately.
 				if c.InstanceClient == nil {
-					dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: instance admin client is nil", c.InstancePath()))
+					errs = append(errs, fmt.Errorf("delete instance %s: instance admin client is nil", c.InstancePath()))
 				} else if err := c.InstanceClient.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{
 					Name: c.InstancePath(),
 				}); err != nil {
-					dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: %w", c.InstancePath(), err))
+					errs = append(errs, fmt.Errorf("delete instance %s: %w", c.InstancePath(), err))
 				}
 			} else if c.dropDatabase {
 				if c.DatabaseClient == nil {
-					dropErrs = append(dropErrs, fmt.Errorf("drop database %s: database admin client is nil", c.DatabasePath()))
+					errs = append(errs, fmt.Errorf("drop database %s: database admin client is nil", c.DatabasePath()))
 				} else if err := c.DatabaseClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
 					Database: c.DatabasePath(),
 				}); err != nil {
-					dropErrs = append(dropErrs, fmt.Errorf("drop database %s: %w", c.DatabasePath(), err))
+					errs = append(errs, fmt.Errorf("drop database %s: %w", c.DatabasePath(), err))
 				}
 			}
 		}
 
-		var errs []error
-		errs = append(errs, dropErrs...)
 		if c.DatabaseClient != nil {
 			errs = append(errs, c.DatabaseClient.Close())
 		}

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -44,7 +44,8 @@ type Clients struct {
 	dropDatabase bool
 	dropInstance bool
 
-	// Pointer-backed to keep exported Clients comparable as a value.
+	// Pointer-backed to avoid embedding a sync.Once copylock in the exported
+	// Clients struct layout.
 	closeState *closeState
 }
 

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -44,6 +44,7 @@ type Clients struct {
 	dropDatabase bool
 	dropInstance bool
 
+	// Pointer-backed to keep exported Clients comparable as a value.
 	closeState *closeState
 }
 

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -44,8 +44,7 @@ type Clients struct {
 	dropDatabase bool
 	dropInstance bool
 
-	closed   bool
-	closeErr error
+	closeState closeState
 }
 
 func (c *Clients) ProjectPath() string  { return projectPath(c.ProjectID) }
@@ -67,8 +66,9 @@ func (c *Clients) URI() string {
 }
 
 // Close closes all Spanner clients.
-// By default, auto-created resources with fixed IDs are dropped before
-// the clients are closed. See [ForceSchemaTeardown] and [SkipSchemaTeardown].
+// By default, auto-created resources with fixed IDs are dropped during Close
+// after the data client is closed and before the admin clients are closed.
+// See [ForceSchemaTeardown] and [SkipSchemaTeardown].
 // [spanner.Client.Close] does not return an error, so only admin client and
 // resource cleanup errors are returned.
 // Close is nil-safe and idempotent. After the first call, subsequent calls
@@ -77,47 +77,44 @@ func (c *Clients) Close() error {
 	if c == nil {
 		return nil
 	}
-	if c.closed {
-		return c.closeErr
-	}
-	c.closed = true
-
-	if c.Client != nil {
-		c.Client.Close()
-	}
-
-	var dropErrs []error
-	ctx := context.Background()
-	if c.dropInstance {
-		// Deleting the instance also removes all databases within it,
-		// so there is no need to drop the database separately.
-		if c.InstanceClient == nil {
-			dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: instance admin client is nil", c.InstancePath()))
-		} else if err := c.InstanceClient.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{
-			Name: c.InstancePath(),
-		}); err != nil {
-			dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: %w", c.InstancePath(), err))
+	return c.closeState.close(func() error {
+		if c.Client != nil {
+			c.Client.Close()
 		}
-	} else if c.dropDatabase {
-		if c.DatabaseClient == nil {
-			dropErrs = append(dropErrs, fmt.Errorf("drop database %s: database admin client is nil", c.DatabasePath()))
-		} else if err := c.DatabaseClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
-			Database: c.DatabasePath(),
-		}); err != nil {
-			dropErrs = append(dropErrs, fmt.Errorf("drop database %s: %w", c.DatabasePath(), err))
-		}
-	}
 
-	var errs []error
-	errs = append(errs, dropErrs...)
-	if c.DatabaseClient != nil {
-		errs = append(errs, c.DatabaseClient.Close())
-	}
-	if c.InstanceClient != nil {
-		errs = append(errs, c.InstanceClient.Close())
-	}
-	c.closeErr = errors.Join(errs...)
-	return c.closeErr
+		var dropErrs []error
+		ctx, cancel := newCloseContext()
+		defer cancel()
+		if c.dropInstance {
+			// Deleting the instance also removes all databases within it,
+			// so there is no need to drop the database separately.
+			if c.InstanceClient == nil {
+				dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: instance admin client is nil", c.InstancePath()))
+			} else if err := c.InstanceClient.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{
+				Name: c.InstancePath(),
+			}); err != nil {
+				dropErrs = append(dropErrs, fmt.Errorf("delete instance %s: %w", c.InstancePath(), err))
+			}
+		} else if c.dropDatabase {
+			if c.DatabaseClient == nil {
+				dropErrs = append(dropErrs, fmt.Errorf("drop database %s: database admin client is nil", c.DatabasePath()))
+			} else if err := c.DatabaseClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
+				Database: c.DatabasePath(),
+			}); err != nil {
+				dropErrs = append(dropErrs, fmt.Errorf("drop database %s: %w", c.DatabasePath(), err))
+			}
+		}
+
+		var errs []error
+		errs = append(errs, dropErrs...)
+		if c.DatabaseClient != nil {
+			errs = append(errs, c.DatabaseClient.Close())
+		}
+		if c.InstanceClient != nil {
+			errs = append(errs, c.InstanceClient.Close())
+		}
+		return errors.Join(errs...)
+	})
 }
 
 // RunEmulator starts a Cloud Spanner Emulator container and performs any

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -1,13 +1,35 @@
 package spanemuboost
 
 import (
+	"errors"
+	"strings"
 	"sync"
 	"testing"
 
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/option"
 )
+
+type closeCountingRuntime struct {
+	closeCalls int
+	closeErr   error
+}
+
+func (*closeCountingRuntime) spanemuboostRuntime()                 {}
+func (*closeCountingRuntime) URI() string                          { return "" }
+func (*closeCountingRuntime) ClientOptions() []option.ClientOption { return nil }
+func (r *closeCountingRuntime) Close() error {
+	r.closeCalls++
+	return r.closeErr
+}
+func (*closeCountingRuntime) ProjectID() string    { return "" }
+func (*closeCountingRuntime) InstanceID() string   { return "" }
+func (*closeCountingRuntime) DatabaseID() string   { return "" }
+func (*closeCountingRuntime) ProjectPath() string  { return "" }
+func (*closeCountingRuntime) InstancePath() string { return "" }
+func (*closeCountingRuntime) DatabasePath() string { return "" }
 
 func TestNewEmulatorWithClients(t *testing.T) {
 	type row struct {
@@ -331,10 +353,154 @@ func TestRuntimeEnvCloseZeroValue(t *testing.T) {
 	if err := env.Close(); err != nil {
 		t.Fatalf("Close() error = %v, want nil", err)
 	}
+	if err := env.Close(); err != nil {
+		t.Fatalf("second Close() error = %v, want nil", err)
+	}
 
 	var nilEnv *RuntimeEnv
 	if err := nilEnv.Close(); err != nil {
 		t.Fatalf("nil Close() error = %v, want nil", err)
+	}
+}
+
+func TestClientsCloseNilSafeAndIdempotent(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var clients *Clients
+		if err := clients.Close(); err != nil {
+			t.Fatalf("nil Close() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("zero value", func(t *testing.T) {
+		clients := &Clients{}
+		if err := clients.Close(); err != nil {
+			t.Fatalf("first Close() error = %v, want nil", err)
+		}
+		if err := clients.Close(); err != nil {
+			t.Fatalf("second Close() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("missing admin client caches first error", func(t *testing.T) {
+		clients := &Clients{
+			ProjectID:    "project",
+			InstanceID:   "instance",
+			dropInstance: true,
+		}
+
+		err1 := clients.Close()
+		if err1 == nil {
+			t.Fatal("first Close() error = nil, want non-nil")
+		}
+		if !strings.Contains(err1.Error(), "instance admin client is nil") {
+			t.Fatalf("first Close() error = %q, want missing instance admin client", err1)
+		}
+
+		err2 := clients.Close()
+		if err2 == nil {
+			t.Fatal("second Close() error = nil, want cached non-nil")
+		}
+		if err2.Error() != err1.Error() {
+			t.Fatalf("second Close() error = %q, want %q", err2, err1)
+		}
+	})
+}
+
+func TestEnvCloseNilSafeAndIdempotent(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var env *Env
+		if err := env.Close(); err != nil {
+			t.Fatalf("nil Close() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("zero value", func(t *testing.T) {
+		env := &Env{}
+		if err := env.Close(); err != nil {
+			t.Fatalf("first Close() error = %v, want nil", err)
+		}
+		if err := env.Close(); err != nil {
+			t.Fatalf("second Close() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("caches first error", func(t *testing.T) {
+		env := &Env{
+			Clients: &Clients{
+				ProjectID:    "project",
+				InstanceID:   "instance",
+				dropInstance: true,
+			},
+		}
+
+		err1 := env.Close()
+		if err1 == nil {
+			t.Fatal("first Close() error = nil, want non-nil")
+		}
+		if !strings.Contains(err1.Error(), "instance admin client is nil") {
+			t.Fatalf("first Close() error = %q, want missing instance admin client", err1)
+		}
+
+		err2 := env.Close()
+		if err2 == nil {
+			t.Fatal("second Close() error = nil, want cached non-nil")
+		}
+		if err2.Error() != err1.Error() {
+			t.Fatalf("second Close() error = %q, want %q", err2, err1)
+		}
+	})
+}
+
+func TestEmulatorCloseNilSafeAndIdempotent(t *testing.T) {
+	var nilEmulator *Emulator
+	if err := nilEmulator.Close(); err != nil {
+		t.Fatalf("nil Close() error = %v, want nil", err)
+	}
+
+	emulator := &Emulator{}
+	if err := emulator.Close(); err != nil {
+		t.Fatalf("first Close() error = %v, want nil", err)
+	}
+	if err := emulator.Close(); err != nil {
+		t.Fatalf("second Close() error = %v, want nil", err)
+	}
+}
+
+func TestRuntimeEnvCloseCachesFirstResult(t *testing.T) {
+	runtimeErr := errors.New("runtime close failed")
+	runtime := &closeCountingRuntime{closeErr: runtimeErr}
+	env := &RuntimeEnv{
+		Clients: &Clients{
+			ProjectID:    "project",
+			InstanceID:   "instance",
+			dropInstance: true,
+		},
+		runtime: runtime,
+	}
+
+	err1 := env.Close()
+	if err1 == nil {
+		t.Fatal("first Close() error = nil, want non-nil")
+	}
+	if runtime.closeCalls != 1 {
+		t.Fatalf("runtime Close() calls after first Close = %d, want 1", runtime.closeCalls)
+	}
+	if !strings.Contains(err1.Error(), "instance admin client is nil") {
+		t.Fatalf("first Close() error = %q, want missing instance admin client", err1)
+	}
+	if !errors.Is(err1, runtimeErr) {
+		t.Fatalf("first Close() error = %v, want wrapped runtime error %v", err1, runtimeErr)
+	}
+
+	err2 := env.Close()
+	if err2 == nil {
+		t.Fatal("second Close() error = nil, want cached non-nil")
+	}
+	if runtime.closeCalls != 1 {
+		t.Fatalf("runtime Close() calls after second Close = %d, want 1", runtime.closeCalls)
+	}
+	if err2.Error() != err1.Error() {
+		t.Fatalf("second Close() error = %q, want %q", err2, err1)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make close helpers nil-safe and idempotent across Clients, Env, RuntimeEnv, Emulator, LazyRuntime, LazyEmulator, and the Omni runtime
- avoid nil-pointer panics in Clients.Close by turning missing teardown clients into explicit close errors
- add focused regression tests for repeated close calls, nil receivers, and cached close results

## Validation
- go test ./... -run 'Test(ClientsCloseNilSafeAndIdempotent|EnvCloseNilSafeAndIdempotent|EmulatorCloseNilSafeAndIdempotent|RuntimeEnvClose(ZeroValue|CachesFirstResult)|LazyCloseNilReceivers|OmniRuntimeCloseZeroValue)$'
- golangci-lint run
- go test ./... *(fails in this environment because testcontainers cannot create the reaper container: Docker bridge network not found)*

Closes #30