### PR TITLE
docs: add AGENTS.md architecture guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,10 @@ When updating docs:
 For code changes, the usual local checks are:
 
 ```sh
-TESTCONTAINERS_RYUK_DISABLED=true go test -race ./...
+go test -race ./...
 golangci-lint run
 git diff --check
 ```
+
+If your local Docker setup requires Ryuk to be disabled, prefix the test
+command with `TESTCONTAINERS_RYUK_DISABLED=true`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,9 +48,10 @@ Omni does **not** add separate exported startup helpers. It plugs into the
 backend-neutral surface instead:
 
 - `Run(..., BackendOmni, ...)`
-- `RunWithClients(..., BackendOmni, ...)`
-- `Setup(..., BackendOmni, ...)`
-- `SetupWithClients(..., BackendOmni, ...)`
+- `Run(ctx, BackendOmni, ...)`
+- `RunWithClients(ctx, BackendOmni, ...)`
+- `Setup(tb, BackendOmni, ...)`
+- `SetupWithClients(tb, BackendOmni, ...)`
 
 Important Omni constraints:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,6 @@ because `NewLazyRuntime(BackendEmulator, ...)` exists.
 Omni does **not** add separate exported startup helpers. It plugs into the
 backend-neutral surface instead:
 
-- `Run(..., BackendOmni, ...)`
 - `Run(ctx, BackendOmni, ...)`
 - `RunWithClients(ctx, BackendOmni, ...)`
 - `Setup(tb, BackendOmni, ...)`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ shared runtime/client abstractions underneath.
 These are the preferred architecture entry points:
 
 - `BackendEmulator`, `BackendOmni`
-- `Runtime`
+- `Runtime`, `RuntimeEnv`
 - `Run`, `RunWithClients`
 - `Setup`, `SetupWithClients`
 - `OpenClients`, `SetupClients`
@@ -98,7 +98,7 @@ Preserve these behaviors:
 ## Key files
 
 - `runtime.go`: backend-neutral runtime API and runtime resolution
-- `spanemuboost.go`: clients, emulator-facing compatibility API
+- `spanemuboost.go`: `Clients`, `OpenClients`, and emulator-facing compatibility API
 - `testing.go`: `Setup*` and `TestMain` helpers
 - `lazy.go`: lazy runtime and lazy emulator behavior
 - `omni.go`: Omni runtime, client config, guardrails

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,11 +71,12 @@ Important Omni constraints:
 
 Current close semantics use a shared internal `closeState` helper. For exported
 types that use that helper, it is kept pointer-backed to avoid exposing
-`sync.Once` copylock fields in the public struct layout. `LazyRuntime` uses a
-separate internal `lazyRuntimeState` by value because its `sync.Once` fields are
-part of the lazy-start state, not the exported close-state helper. Treat
-`LazyRuntime` as a pointer-owned handle: create it with `NewLazyRuntime(...)`
-and pass the returned `*LazyRuntime` around rather than copying it by value.
+`sync.Once` copylock fields in the public struct layout. `LazyRuntime` and
+`LazyEmulator` use a separate internal `lazyRuntimeState` by value because
+their `sync.Once` fields are part of the lazy-start state, not the exported
+close-state helper. Treat them as pointer-owned handles: create them with
+`NewLazyRuntime(...)` or `NewLazyEmulator(...)` and pass the returned pointers
+around rather than copying them by value.
 
 ## Bootstrap and rollback rules
 
@@ -101,7 +102,7 @@ Preserve these behaviors:
 
 - `runtime.go`: backend-neutral runtime API and runtime resolution
 - `spanemuboost.go`: `Clients`, `OpenClients`, and emulator-facing compatibility API
-- `emulator.go`: `Emulator`, `Env`, `LazyEmulator`, and emulator-specific options
+- `emulator.go`: `Emulator`, `Env`, `LazyEmulator`, and emulator-specific runtime logic
 - `options.go`: `Option` and `With*` helpers for backend configuration
 - `testing.go`: `Setup*` and `TestMain` helpers
 - `lazy.go`: lazy runtime behavior

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Important Omni constraints:
 - `Close()` paths are expected to be **nil-safe** and **idempotent**
 - `Setup*` helpers own cleanup via `tb.Cleanup`
 - `TestMain` helpers own cleanup via `os.Exit` wrappers
-- fixed IDs default to schema teardown on client close
+- auto-created resources with fixed IDs default to schema teardown on client close
 - random IDs do not default to teardown
 - runtime-owned environments (`RunEmulatorWithClients`, `SetupEmulatorWithClients`,
   Omni runtime envs) disable schema teardown unless explicitly forced

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,9 @@ Current close semantics use a shared internal `closeState` helper. For exported
 types that use that helper, it is kept pointer-backed to avoid exposing
 `sync.Once` copylock fields in the public struct layout. `LazyRuntime` uses a
 separate internal `lazyRuntimeState` by value because its `sync.Once` fields are
-part of the lazy-start state, not the exported close-state helper.
+part of the lazy-start state, not the exported close-state helper. Treat
+`LazyRuntime` as a pointer-owned handle: create it with `NewLazyRuntime(...)`
+and pass the returned `*LazyRuntime` around rather than copying it by value.
 
 ## Bootstrap and rollback rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,10 @@ Important Omni constraints:
   Omni runtime envs) disable schema teardown unless explicitly forced
 
 Current close semantics use a shared internal `closeState` helper. For exported
-types, it is kept pointer-backed to avoid exposing `sync.Once` copylock fields
-in the public struct layout.
+types that use that helper, it is kept pointer-backed to avoid exposing
+`sync.Once` copylock fields in the public struct layout. `LazyRuntime` uses a
+separate internal `lazyRuntimeState` by value because its `sync.Once` fields are
+part of the lazy-start state, not the exported close-state helper.
 
 ## Bootstrap and rollback rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,10 @@ Preserve these behaviors:
 
 - `runtime.go`: backend-neutral runtime API and runtime resolution
 - `spanemuboost.go`: `Clients`, `OpenClients`, and emulator-facing compatibility API
+- `emulator.go`: `Emulator`, `Env`, `LazyEmulator`, and emulator-specific options
+- `options.go`: `Option` and `With*` helpers for backend configuration
 - `testing.go`: `Setup*` and `TestMain` helpers
-- `lazy.go`: lazy runtime and lazy emulator behavior
+- `lazy.go`: lazy runtime behavior
 - `omni.go`: Omni runtime, client config, guardrails
 - `internal.go`: shared bootstrap, rollback, client construction
 - `close.go`: shared close-state helper

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Important Omni constraints:
 ## Lifecycle and teardown rules
 
 - `Close()` paths are expected to be **nil-safe** and **idempotent**
-- `Setup*` helpers own cleanup via `t.Cleanup`
+- `Setup*` helpers own cleanup via `tb.Cleanup`
 - `TestMain` helpers own cleanup via `os.Exit` wrappers
 - fixed IDs default to schema teardown on client close
 - random IDs do not default to teardown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,124 @@
+# AGENTS
+
+## Purpose
+
+`spanemuboost` is still primarily an emulator-focused package, but its runtime
+layer is now backend-neutral. The public architecture supports both:
+
+- **Cloud Spanner Emulator** as the default, stable path
+- **Spanner Omni** as an **experimental** backend
+
+Keep that framing in docs and code changes: emulator-first, Omni-experimental,
+shared runtime/client abstractions underneath.
+
+## Public architecture
+
+### Backend-neutral runtime layer
+
+These are the preferred architecture entry points:
+
+- `BackendEmulator`, `BackendOmni`
+- `Runtime`
+- `Run`, `RunWithClients`
+- `Setup`, `SetupWithClients`
+- `OpenClients`, `SetupClients`
+- `NewLazyRuntime`
+
+`Runtime` is a started backend instance with connection metadata (`URI`,
+`ClientOptions`, resource paths) and lifecycle (`Close`).
+
+`OpenClients` and `SetupClients` intentionally accept package-provided runtime
+values only: started runtimes, `*LazyRuntime`, and `*LazyEmulator`.
+
+### Emulator compatibility layer
+
+These remain first-class and should stay easy to use:
+
+- `Emulator`, `Env`
+- `RunEmulator`, `RunEmulatorWithClients`
+- `SetupEmulator`, `SetupEmulatorWithClients`
+- `NewLazyEmulator`
+
+`NewLazyEmulator` is a backward-compatible wrapper. Do not remove it just
+because `NewLazyRuntime(BackendEmulator, ...)` exists.
+
+### Omni architecture
+
+Omni does **not** add separate exported startup helpers. It plugs into the
+backend-neutral surface instead:
+
+- `Run(..., BackendOmni, ...)`
+- `RunWithClients(..., BackendOmni, ...)`
+- `Setup(..., BackendOmni, ...)`
+- `SetupWithClients(..., BackendOmni, ...)`
+
+Important Omni constraints:
+
+- use the public Spanner gRPC endpoint on port `15000`
+- keep Omni positioned as experimental
+- keep backend guardrails unless a caller explicitly disables them
+- use `RecommendedOmniClientConfig()` as the base for external Go clients
+
+## Lifecycle and teardown rules
+
+- `Close()` paths are expected to be **nil-safe** and **idempotent**
+- `Setup*` helpers own cleanup via `t.Cleanup`
+- `TestMain` helpers own cleanup via `os.Exit` wrappers
+- fixed IDs default to schema teardown on client close
+- random IDs do not default to teardown
+- runtime-owned environments (`RunEmulatorWithClients`, `SetupEmulatorWithClients`,
+  Omni runtime envs) disable schema teardown unless explicitly forced
+
+Current close semantics use a shared internal `closeState` helper. For exported
+types, it is kept pointer-backed to avoid exposing `sync.Once` copylock fields
+in the public struct layout.
+
+## Bootstrap and rollback rules
+
+- bootstrap is shared across backends where possible
+- `OpenClients` inherits runtime IDs and reopen semantics from the started runtime
+- partial bootstrap failures must not leak created schema resources
+- rollback logic is intentionally explicit about instance-vs-database teardown
+
+When touching bootstrap behavior, read `internal.go` first.
+
+## Lazy runtime rules
+
+`LazyRuntime` is the backend-neutral lazy entry point.
+
+Preserve these behaviors:
+
+- startup runs once
+- startup panics are re-surfaced on later `Get`
+- typed-nil runtimes are treated as nil
+- `Close` is safe before initialization and after repeated calls
+
+## Key files
+
+- `runtime.go`: backend-neutral runtime API and runtime resolution
+- `spanemuboost.go`: clients, emulator-facing compatibility API
+- `testing.go`: `Setup*` and `TestMain` helpers
+- `lazy.go`: lazy runtime and lazy emulator behavior
+- `omni.go`: Omni runtime, client config, guardrails
+- `internal.go`: shared bootstrap, rollback, client construction
+- `close.go`: shared close-state helper
+
+## Documentation guidance
+
+When updating docs:
+
+- keep README emulator-centered in tone
+- describe backend-neutral APIs accurately
+- describe Omni as experimental, not parity-complete
+- do not imply separate exported Omni helper families that do not exist
+- mention `SPANEMUBOOST_ENABLE_OMNI_TESTS=1` for opt-in Omni test coverage
+
+## Validation
+
+For code changes, the usual local checks are:
+
+```sh
+TESTCONTAINERS_RYUK_DISABLED=true go test -race ./...
+golangci-lint run
+git diff --check
+```


### PR DESCRIPTION
## Overview

Add AGENTS.md to document the backend-neutral runtime architecture and provide architectural guidance for agents and contributors.

## What's included

- **Backend-neutral runtime layer**: Run, Setup, OpenClients, SetupClients, NewLazyRuntime
- **Emulator compatibility layer**: emulator-specific helpers and migration path
- **Experimental Omni position**: single-server gRPC backend, not a separate helper API
- **Lifecycle and teardown rules**: nil-safe Close, t.Cleanup ownership, schema teardown defaults, closeState rationale
- **Bootstrap and rollback semantics**: shared bootstrap, partial failure handling, instance vs database teardown
- **Lazy runtime rules**: once-only startup, panic tracking and re-surfacing, nil-safety, idempotent Close
- **Key files and their roles**: core types, helpers, tests, validation commands
- **Documentation guidance**: how to keep AGENTS.md aligned with future changes

## Related

- README.md has been verified to reflect the current backend-neutral + Omni + LazyRuntime architecture
- No breaking changes to public APIs