### PR TITLE
Clarify RuntimeHandle and backend-neutral API stability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,14 +18,20 @@ shared runtime/client abstractions underneath.
 These are the preferred architecture entry points:
 
 - `BackendEmulator`, `BackendOmni`
+- `RuntimeHandle`
 - `Runtime`, `RuntimeEnv`
 - `Run`, `RunWithClients`
 - `Setup`, `SetupWithClients`
 - `OpenClients`, `SetupClients`
 - `NewLazyRuntime`
 
+`RuntimeHandle` is the sealed public handle type accepted by `OpenClients` and
+`SetupClients`.
+
 `Runtime` is a started backend instance with connection metadata (`URI`,
-`ClientOptions`, resource paths) and lifecycle (`Close`).
+`ClientOptions`, resource paths) and lifecycle (`Close`). Treat this backend-
+neutral surface as the stable API layer; treat Omni-specific behavior as
+experimental.
 
 `OpenClients` and `SetupClients` intentionally accept package-provided runtime
 values only: started runtimes, `*LazyRuntime`, and `*LazyEmulator`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,8 @@ backend-neutral surface as the stable API layer; treat Omni-specific behavior
 as experimental.
 
 `OpenClients` and `SetupClients` intentionally accept package-provided runtime
-values only: started runtimes, `*LazyRuntime`, and `*LazyEmulator`.
+values only: started runtimes, `*Emulator`, `*LazyRuntime`, and
+`*LazyEmulator`.
 
 ### Emulator compatibility layer
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@ These are the preferred architecture entry points:
 - `OpenClients`, `SetupClients`
 - `NewLazyRuntime`
 
-`RuntimeHandle` is the sealed public handle type accepted by `OpenClients` and
-`SetupClients`.
+`RuntimeHandle` is the package-owned public handle type accepted by
+`OpenClients` and `SetupClients`.
 
 `Runtime` is a started backend instance with connection metadata (`URI`,
 `ClientOptions`, resource paths) and lifecycle (`Close`). Treat this

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,9 @@ These are the preferred architecture entry points:
 `SetupClients`.
 
 `Runtime` is a started backend instance with connection metadata (`URI`,
-`ClientOptions`, resource paths) and lifecycle (`Close`). Treat this backend-
-neutral surface as the stable API layer; treat Omni-specific behavior as
-experimental.
+`ClientOptions`, resource paths) and lifecycle (`Close`). Treat this
+backend-neutral surface as the stable API layer; treat Omni-specific behavior
+as experimental.
 
 `OpenClients` and `SetupClients` intentionally accept package-provided runtime
 values only: started runtimes, `*LazyRuntime`, and `*LazyEmulator`.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ func TestSharedHelpers(t *testing.T) {
 }
 ```
 
-`Run`, `RunWithClients`, `Setup`, `SetupWithClients`, `OpenClients`, `SetupClients`, and `NewLazyRuntime` work across emulator and Omni. That backend-neutral API surface is intended to remain the primary public entry point; the experimental part is the `BackendOmni` backend and its backend-specific behavior, not the existence of the shared helpers themselves. Omni does not add separate exported startup or client-opening helpers.
+`Run`, `RunWithClients`, `Setup`, `SetupWithClients`, `OpenClients`, `SetupClients`, and `NewLazyRuntime` work across emulator and Omni. This backend-neutral API surface is the primary stable entry point; only the `BackendOmni` backend and its specific behaviors are considered experimental. Omni does not add separate exported startup or client-opening helpers.
 
 ### Shared emulator patterns
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ func TestSharedHelpers(t *testing.T) {
 }
 ```
 
-`Run`, `RunWithClients`, `Setup`, `SetupWithClients`, `OpenClients`, `SetupClients`, and `NewLazyRuntime` work across emulator and Omni. `BackendOmni` is the backend selector; Omni does not add separate exported startup or client-opening helpers.
+`Run`, `RunWithClients`, `Setup`, `SetupWithClients`, `OpenClients`, `SetupClients`, and `NewLazyRuntime` work across emulator and Omni. That backend-neutral API surface is intended to remain the primary public entry point; the experimental part is the `BackendOmni` backend and its backend-specific behavior, not the existence of the shared helpers themselves. Omni does not add separate exported startup or client-opening helpers.
 
 ### Shared emulator patterns
 

--- a/omni.go
+++ b/omni.go
@@ -52,8 +52,8 @@ func (o *omniRuntime) ClientOptions() []option.ClientOption {
 
 // RecommendedOmniClientConfig returns the recommended [spanner.ClientConfig]
 // for a Go Spanner data client connecting to the experimental Omni backend.
-// The helper remains part of the backend-neutral API surface, but its Omni-
-// specific recommendations may evolve before v1.
+// The helper remains part of the backend-neutral API surface, but its
+// Omni-specific recommendations may evolve before v1.
 func RecommendedOmniClientConfig() spanner.ClientConfig {
 	return spanner.ClientConfig{
 		DisableNativeMetrics: true,

--- a/omni.go
+++ b/omni.go
@@ -51,7 +51,9 @@ func (o *omniRuntime) ClientOptions() []option.ClientOption {
 }
 
 // RecommendedOmniClientConfig returns the recommended [spanner.ClientConfig]
-// for a Go Spanner data client connecting to Omni.
+// for a Go Spanner data client connecting to the experimental Omni backend.
+// The helper remains part of the backend-neutral API surface, but its Omni-
+// specific recommendations may evolve before v1.
 func RecommendedOmniClientConfig() spanner.ClientConfig {
 	return spanner.ClientConfig{
 		DisableNativeMetrics: true,

--- a/options.go
+++ b/options.go
@@ -33,8 +33,8 @@ type emulatorOptions struct {
 }
 
 // Option configures spanemuboost runtime bootstrap behavior.
-// Use the package-provided With*, Enable*, Disable*, Force*, and Skip* helpers;
-// external Option implementations are not supported.
+// Use the package-provided With*, Without*, Enable*, Disable*, Force*, and
+// Skip* helpers; external Option implementations are not supported.
 type Option func(*emulatorOptions) error
 
 // WithContainerCustomizers sets any testcontainers.ContainerCustomizer

--- a/options.go
+++ b/options.go
@@ -32,6 +32,9 @@ type emulatorOptions struct {
 	clientOptionsForClient []option.ClientOption
 }
 
+// Option configures spanemuboost runtime bootstrap behavior.
+// Use the package-provided With*, Enable*, Disable*, Force*, and Skip* helpers;
+// external Option implementations are not supported.
 type Option func(*emulatorOptions) error
 
 // WithContainerCustomizers sets any testcontainers.ContainerCustomizer

--- a/runtime.go
+++ b/runtime.go
@@ -11,24 +11,38 @@ import (
 )
 
 // Backend identifies the runtime implementation to start.
+// Callers should use the exported Backend* constants; other values are rejected.
 type Backend string
 
 const (
 	// BackendEmulator starts the Cloud Spanner Emulator backend.
 	BackendEmulator Backend = "emulator"
 	// BackendOmni starts the experimental Spanner Omni backend.
+	// Backend-specific behavior for Omni may change before v1.
 	// Use [RecommendedOmniClientConfig] for external Go clients.
 	BackendOmni Backend = "omni"
 )
 
-type abstractRuntime interface {
+// RuntimeHandle is a package-provided runtime value accepted by [OpenClients]
+// and [SetupClients].
+//
+// Supported handles are started [Runtime] values returned by [Run] or [Setup],
+// as well as [*LazyRuntime] and [*LazyEmulator]. External implementations are
+// not supported.
+type RuntimeHandle interface {
 	spanemuboostRuntime()
 }
 
-// Runtime is a started Spanner-compatible test runtime.
+// Runtime is a started backend-neutral Spanner-compatible test runtime returned
+// by [Run] or [Setup].
+//
+// This backend-neutral API surface is intended to remain the primary public
+// entry point. Backend-specific behavior may evolve independently, especially
+// for the experimental [BackendOmni] backend.
+//
 // Implementations are provided by this package.
 type Runtime interface {
-	abstractRuntime
+	RuntimeHandle
 	URI() string
 	ClientOptions() []option.ClientOption
 	Close() error
@@ -73,7 +87,7 @@ func disableSchemaTeardownUnlessForced(opts *emulatorOptions, clients *Clients) 
 // OpenClients and SetupClients intentionally accept either a started Runtime,
 // a *LazyRuntime, or a *LazyEmulator without adding another startup method to
 // the public Runtime API.
-func resolveRuntime(ctx context.Context, runtime abstractRuntime) (runtimeInstance, error) {
+func resolveRuntime(ctx context.Context, runtime RuntimeHandle) (runtimeInstance, error) {
 	if runtime == nil {
 		return nil, errors.New("spanemuboost: runtime is nil; use *Emulator, *LazyRuntime, *LazyEmulator, or a Runtime returned by Run or Setup")
 	}
@@ -122,6 +136,8 @@ func isNilRuntimeValue(runtime Runtime) bool {
 }
 
 // RuntimeEnv combines a [Runtime] with [Clients] for backend-neutral startup.
+// When created with [BackendOmni], backend-specific behavior remains
+// experimental.
 type RuntimeEnv struct {
 	*Clients
 	runtime Runtime
@@ -155,6 +171,7 @@ func (e *RuntimeEnv) Close() error {
 }
 
 // Run starts the selected backend and returns it as a backend-neutral runtime.
+// When backend is [BackendOmni], backend-specific behavior remains experimental.
 func Run(ctx context.Context, backend Backend, options ...Option) (Runtime, error) {
 	switch backend {
 	case BackendEmulator:
@@ -167,6 +184,7 @@ func Run(ctx context.Context, backend Backend, options ...Option) (Runtime, erro
 }
 
 // RunWithClients starts the selected backend and returns managed clients.
+// When backend is [BackendOmni], backend-specific behavior remains experimental.
 func RunWithClients(ctx context.Context, backend Backend, options ...Option) (*RuntimeEnv, error) {
 	switch backend {
 	case BackendEmulator:
@@ -182,7 +200,9 @@ func RunWithClients(ctx context.Context, backend Backend, options ...Option) (*R
 	}
 }
 
-// Setup starts the selected backend and registers cleanup with [testing.TB.Cleanup].
+// Setup starts the selected backend and registers cleanup with
+// [testing.TB.Cleanup].
+// When backend is [BackendOmni], backend-specific behavior remains experimental.
 func Setup(tb testing.TB, backend Backend, options ...Option) Runtime {
 	tb.Helper()
 
@@ -199,6 +219,7 @@ func Setup(tb testing.TB, backend Backend, options ...Option) Runtime {
 
 // SetupWithClients starts the selected backend with managed clients and
 // registers cleanup with [testing.TB.Cleanup].
+// When backend is [BackendOmni], backend-specific behavior remains experimental.
 func SetupWithClients(tb testing.TB, backend Backend, options ...Option) *RuntimeEnv {
 	tb.Helper()
 

--- a/runtime.go
+++ b/runtime.go
@@ -27,8 +27,8 @@ const (
 // and [SetupClients].
 //
 // Supported handles are started [Runtime] values returned by [Run] or [Setup],
-// as well as [*LazyRuntime] and [*LazyEmulator]. External implementations are
-// not supported.
+// as well as [*Emulator], [*LazyRuntime], and [*LazyEmulator]. External
+// implementations are not supported.
 type RuntimeHandle interface {
 	spanemuboostRuntime()
 }

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -174,9 +174,9 @@ func RunEmulatorWithClients(ctx context.Context, options ...Option) (*Env, error
 	return &Env{Clients: clients, emulator: emu}, nil
 }
 
-// OpenClients connects to an existing runtime and opens Spanner clients.
-// The runtime parameter accepts [*Emulator], [*LazyRuntime], [*LazyEmulator],
-// and the [Runtime] returned by [Run] or [Setup].
+// OpenClients connects to an existing [RuntimeHandle] and opens Spanner clients.
+// Supported handles are [*Emulator], [*LazyRuntime], [*LazyEmulator], and the
+// [Runtime] returned by [Run] or [Setup].
 // When a lazy runtime is passed, it is started automatically on first use.
 // The parameter type is intentionally limited to package-provided runtime values
 // so callers can use lazy runtime handles without adding another startup method
@@ -188,7 +188,7 @@ func RunEmulatorWithClients(ctx context.Context, options ...Option) (*Env, error
 // [EnableAutoConfig]).
 // Call [Clients.Close] to close the clients when done.
 // In tests, prefer [SetupClients] which handles cleanup automatically.
-func OpenClients(ctx context.Context, runtime abstractRuntime, options ...Option) (*Clients, error) {
+func OpenClients(ctx context.Context, runtime RuntimeHandle, options ...Option) (*Clients, error) {
 	r, err := resolveRuntime(ctx, runtime)
 	if err != nil {
 		return nil, err

--- a/testing.go
+++ b/testing.go
@@ -152,17 +152,17 @@ func SetupEmulatorWithClients(tb testing.TB, options ...Option) *Env {
 	}, "env")
 }
 
-// SetupClients opens Spanner clients against an existing runtime and registers
-// cleanup via [testing.TB.Cleanup]. It calls [testing.TB.Fatal] on setup error.
-// The runtime parameter accepts [*Emulator], [*LazyRuntime], [*LazyEmulator],
-// and the [Runtime] returned by [Run] or [Setup].
+// SetupClients opens Spanner clients against an existing [RuntimeHandle] and
+// registers cleanup via [testing.TB.Cleanup]. It calls [testing.TB.Fatal] on
+// setup error. Supported handles are [*Emulator], [*LazyRuntime],
+// [*LazyEmulator], and the [Runtime] returned by [Run] or [Setup].
 // When a lazy runtime is passed, it is started automatically on first use.
 // The parameter type is intentionally limited to package-provided runtime values
 // so callers can use lazy runtime handles without adding another startup method
 // to the public [Runtime] interface.
 // Options inherit the runtime's projectID, instanceID, and databaseID.
 // Use [OpenClients] if you need a [context.Context] or are not in a test.
-func SetupClients(tb testing.TB, runtime abstractRuntime, options ...Option) *Clients {
+func SetupClients(tb testing.TB, runtime RuntimeHandle, options ...Option) *Clients {
 	tb.Helper()
 
 	clients, err := OpenClients(tb.Context(), runtime, options...)


### PR DESCRIPTION
## Summary
- introduce an exported sealed `RuntimeHandle` name for values accepted by `OpenClients` and `SetupClients`
- clarify in godoc that the backend-neutral runtime API is the primary public surface while `BackendOmni` behavior remains experimental
- document that `Option` implementations are package-owned and keep README/AGENTS aligned with that API stance

## Testing
- TESTCONTAINERS_RYUK_DISABLED=true go test -v ./...
- golangci-lint run
