### PR TITLE
Expose resolved runtime platform metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ These are the preferred architecture entry points:
 - `Run`, `RunWithClients`
 - `Setup`, `SetupWithClients`
 - `OpenClients`, `SetupClients`
+- `RuntimePlatform`
 - `NewLazyRuntime`
 
 `RuntimeHandle` is the package-owned public handle type accepted by

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ func TestSharedHelpers(t *testing.T) {
 }
 ```
 
-`Run`, `RunWithClients`, `Setup`, `SetupWithClients`, `OpenClients`, `SetupClients`, and `NewLazyRuntime` work across emulator and Omni. This backend-neutral API surface is the primary stable entry point; only the `BackendOmni` backend and its specific behaviors are considered experimental. Omni does not add separate exported startup or client-opening helpers.
+`Run`, `RunWithClients`, `Setup`, `SetupWithClients`, `OpenClients`, `SetupClients`, `RuntimePlatform`, and `NewLazyRuntime` work across emulator and Omni. This backend-neutral API surface is the primary stable entry point; only the `BackendOmni` backend and its specific behaviors are considered experimental. Omni does not add separate exported startup or client-opening helpers.
+
+Use `RuntimePlatform(ctx, runtime)` when you want to surface the actual resolved container platform for a package-provided runtime handle without downcasting back to `*Emulator`.
 
 ### Shared emulator patterns
 

--- a/emulator.go
+++ b/emulator.go
@@ -97,6 +97,10 @@ func (e *Emulator) inheritedOptions(options ...Option) (*emulatorOptions, error)
 	return applyOptionsWithBase(base, options...)
 }
 
+func (e *Emulator) runtimePlatform(ctx context.Context) (string, error) {
+	return containerPlatform(ctx, e.container)
+}
+
 // LazyEmulator defers emulator startup until first use.
 // Use [NewLazyEmulator] in a package-level var, then pass directly to [SetupClients]
 // or [OpenClients]. Call [LazyEmulator.Setup] or [LazyEmulator.Get] for standalone access.

--- a/internal.go
+++ b/internal.go
@@ -15,6 +15,7 @@ import (
 	"cloud.google.com/go/spanner/admin/instance/apiv1"
 	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
 	dcontainer "github.com/docker/docker/api/types/container"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/testcontainers/testcontainers-go"
 	tcspanner "github.com/testcontainers/testcontainers-go/modules/gcloud/spanner"
 	"google.golang.org/api/option"
@@ -56,6 +57,47 @@ func newEmulator(ctx context.Context, opts *emulatorOptions) (container *tcspann
 	}
 
 	return container, teardown, nil
+}
+
+func containerPlatform(ctx context.Context, container testcontainers.Container) (string, error) {
+	if container == nil {
+		return "", errors.New("spanemuboost: container is nil")
+	}
+	info, err := container.Inspect(ctx)
+	if err != nil {
+		return "", fmt.Errorf("spanemuboost: inspect container platform: %w", err)
+	}
+	return inspectContainerPlatform(info)
+}
+
+func inspectContainerPlatform(info *dcontainer.InspectResponse) (string, error) {
+	if info == nil {
+		return "", errors.New("spanemuboost: container inspect response is nil")
+	}
+	if platform := descriptorPlatformString(info.ImageManifestDescriptor); platform != "" {
+		return platform, nil
+	}
+	if info.ContainerJSONBase != nil && info.Platform != "" {
+		return info.Platform, nil
+	}
+	return "", errors.New("spanemuboost: container platform metadata unavailable")
+}
+
+func descriptorPlatformString(desc *ocispec.Descriptor) string {
+	if desc == nil || desc.Platform == nil {
+		return ""
+	}
+	return ociPlatformString(desc.Platform)
+}
+
+func ociPlatformString(platform *ocispec.Platform) string {
+	if platform == nil || platform.OS == "" || platform.Architecture == "" {
+		return ""
+	}
+	if platform.Variant == "" {
+		return platform.OS + "/" + platform.Architecture
+	}
+	return platform.OS + "/" + platform.Architecture + "/" + platform.Variant
 }
 
 // executeDMLs creates a short-lived internal client solely for bootstrap DML

--- a/omni.go
+++ b/omni.go
@@ -155,6 +155,10 @@ func (o *omniRuntime) inheritedOptions(options ...Option) (*emulatorOptions, err
 	return applyOmniOptionsWithBase(base, options...)
 }
 
+func (o *omniRuntime) runtimePlatform(ctx context.Context) (string, error) {
+	return containerPlatform(ctx, o.container)
+}
+
 func applyOmniOptions(options ...Option) (*emulatorOptions, error) {
 	opts := &emulatorOptions{disableCreateInstance: true}
 	for _, opt := range options {

--- a/omni_test.go
+++ b/omni_test.go
@@ -288,6 +288,11 @@ func TestRunOmni(t *testing.T) {
 	if len(omni.ClientOptions()) < 3 {
 		t.Fatalf("ClientOptions() returned %d options, want at least 3", len(omni.ClientOptions()))
 	}
+	if platform, err := RuntimePlatform(t.Context(), omni); err != nil {
+		t.Fatalf("RuntimePlatform() error = %v, want nil", err)
+	} else if platform == "" {
+		t.Fatal("RuntimePlatform() returned empty platform")
+	}
 
 	client, err := spanner.NewClientWithConfig(t.Context(), omni.DatabasePath(), RecommendedOmniClientConfig(), omni.ClientOptions()...)
 	if err != nil {
@@ -465,6 +470,12 @@ func TestLazyRuntimeWithOmni(t *testing.T) {
 			t.Errorf("failed to close lazy runtime: %v", err)
 		}
 	}()
+
+	if platform, err := RuntimePlatform(t.Context(), lazy); err != nil {
+		t.Fatalf("RuntimePlatform() error = %v, want nil", err)
+	} else if platform == "" {
+		t.Fatal("RuntimePlatform() returned empty platform")
+	}
 
 	clients := SetupClients(t, lazy,
 		WithRandomDatabaseID(),

--- a/runtime.go
+++ b/runtime.go
@@ -61,7 +61,8 @@ type runtimeInstance interface {
 }
 
 // RuntimePlatform returns the actual resolved container platform (for example,
-// "linux/amd64" or "linux/arm64") for a package-provided runtime handle.
+// "linux/amd64", "linux/arm64", or, when available, a variant-qualified value
+// such as "linux/arm64/v8") for a package-provided runtime handle.
 //
 // It accepts the same started and lazy handles as [OpenClients] and
 // [SetupClients], and resolves lazy handles by starting them on first use.

--- a/runtime.go
+++ b/runtime.go
@@ -57,6 +57,20 @@ type Runtime interface {
 type runtimeInstance interface {
 	Runtime
 	inheritedOptions(...Option) (*emulatorOptions, error)
+	runtimePlatform(context.Context) (string, error)
+}
+
+// RuntimePlatform returns the actual resolved container platform (for example,
+// "linux/amd64" or "linux/arm64") for a package-provided runtime handle.
+//
+// It accepts the same started and lazy handles as [OpenClients] and
+// [SetupClients], and resolves lazy handles by starting them on first use.
+func RuntimePlatform(ctx context.Context, runtime RuntimeHandle) (string, error) {
+	resolved, err := resolveRuntime(ctx, runtime)
+	if err != nil {
+		return "", err
+	}
+	return resolved.runtimePlatform(ctx)
 }
 
 func inheritedRuntimeOptions(opts *emulatorOptions) *emulatorOptions {

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -8,7 +8,9 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	dcontainer "github.com/docker/docker/api/types/container"
 	"github.com/google/go-cmp/cmp"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"google.golang.org/api/option"
 )
 
@@ -770,6 +772,82 @@ func TestClientsAccessors(t *testing.T) {
 		t.Error("URI() is empty")
 	} else if uri != emu.URI() {
 		t.Errorf("URI() = %q, want %q (from emulator)", uri, emu.URI())
+	}
+}
+
+func TestRuntimePlatformNilHandle(t *testing.T) {
+	_, err := RuntimePlatform(t.Context(), nil)
+	if err == nil {
+		t.Fatal("RuntimePlatform() error = nil, want non-nil")
+	}
+}
+
+func TestInspectContainerPlatform(t *testing.T) {
+	t.Run("prefers manifest platform", func(t *testing.T) {
+		got, err := inspectContainerPlatform(&dcontainer.InspectResponse{
+			ContainerJSONBase: &dcontainer.ContainerJSONBase{Platform: "linux/amd64"},
+			ImageManifestDescriptor: &ocispec.Descriptor{
+				Platform: &ocispec.Platform{
+					OS:           "linux",
+					Architecture: "arm64",
+					Variant:      "v8",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("inspectContainerPlatform() error = %v, want nil", err)
+		}
+		if got != "linux/arm64/v8" {
+			t.Fatalf("inspectContainerPlatform() = %q, want %q", got, "linux/arm64/v8")
+		}
+	})
+
+	t.Run("falls back to inspect platform string", func(t *testing.T) {
+		got, err := inspectContainerPlatform(&dcontainer.InspectResponse{
+			ContainerJSONBase: &dcontainer.ContainerJSONBase{Platform: "linux/amd64"},
+		})
+		if err != nil {
+			t.Fatalf("inspectContainerPlatform() error = %v, want nil", err)
+		}
+		if got != "linux/amd64" {
+			t.Fatalf("inspectContainerPlatform() = %q, want %q", got, "linux/amd64")
+		}
+	})
+
+	t.Run("errors when unavailable", func(t *testing.T) {
+		_, err := inspectContainerPlatform(&dcontainer.InspectResponse{})
+		if err == nil {
+			t.Fatal("inspectContainerPlatform() error = nil, want non-nil")
+		}
+	})
+}
+
+func TestRuntimePlatformWithStartedRuntime(t *testing.T) {
+	runtime := Setup(t, BackendEmulator, EnableInstanceAutoConfigOnly())
+
+	got, err := RuntimePlatform(t.Context(), runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == "" {
+		t.Fatal("RuntimePlatform() returned empty platform")
+	}
+}
+
+func TestRuntimePlatformWithLazyRuntime(t *testing.T) {
+	lazy := NewLazyRuntime(BackendEmulator, EnableInstanceAutoConfigOnly())
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			t.Errorf("failed to close lazy runtime: %v", err)
+		}
+	}()
+
+	got, err := RuntimePlatform(t.Context(), lazy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == "" {
+		t.Fatal("RuntimePlatform() returned empty platform")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a narrow `RuntimePlatform` helper for package-provided runtime handles
- resolve actual container platform metadata from inspect data without requiring `*Emulator` downcasts
- cover platform parsing and emulator-backed runtime handles with tests

Closes #45