### PR TITLE
Document OS-only RuntimePlatform values

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ func TestSharedHelpers(t *testing.T) {
 
 `Run`, `RunWithClients`, `Setup`, `SetupWithClients`, `OpenClients`, `SetupClients`, `RuntimePlatform`, and `NewLazyRuntime` work across emulator and Omni. This backend-neutral API surface is the primary stable entry point; only the `BackendOmni` backend and its specific behaviors are considered experimental. Omni does not add separate exported startup or client-opening helpers.
 
-Use `RuntimePlatform(ctx, runtime)` when you want to surface the actual resolved container platform for a package-provided runtime handle without downcasting back to `*Emulator`.
+Use `RuntimePlatform(ctx, runtime)` when you want to surface the actual resolved container platform for a package-provided runtime handle without downcasting back to `*Emulator`. Depending on what metadata the underlying runtime exposes, that may be an `os/arch` string such as `linux/amd64`, a variant-qualified string such as `linux/arm64/v8`, or an OS-only value such as `linux`.
 
 ### Shared emulator patterns
 

--- a/runtime.go
+++ b/runtime.go
@@ -63,6 +63,8 @@ type runtimeInstance interface {
 // RuntimePlatform returns the actual resolved container platform (for example,
 // "linux/amd64", "linux/arm64", or, when available, a variant-qualified value
 // such as "linux/arm64/v8") for a package-provided runtime handle.
+// When the underlying runtime only exposes partial metadata, it may return an
+// OS-only value such as "linux".
 //
 // It accepts the same started and lazy handles as [OpenClients] and
 // [SetupClients], and resolves lazy handles by starting them on first use.

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -814,6 +814,18 @@ func TestInspectContainerPlatform(t *testing.T) {
 		}
 	})
 
+	t.Run("allows os-only inspect platform string", func(t *testing.T) {
+		got, err := inspectContainerPlatform(&dcontainer.InspectResponse{
+			ContainerJSONBase: &dcontainer.ContainerJSONBase{Platform: "linux"},
+		})
+		if err != nil {
+			t.Fatalf("inspectContainerPlatform() error = %v, want nil", err)
+		}
+		if got != "linux" {
+			t.Fatalf("inspectContainerPlatform() = %q, want %q", got, "linux")
+		}
+	})
+
 	t.Run("errors when unavailable", func(t *testing.T) {
 		_, err := inspectContainerPlatform(&dcontainer.InspectResponse{})
 		if err == nil {


### PR DESCRIPTION
## Summary
- document that `RuntimePlatform` may return OS-only values such as `linux` when only partial platform metadata is available
- mirror that contract in the README so downstream diagnostics code can validate it correctly
- add a unit test covering the OS-only fallback path

Closes #47