### PR TITLE
Bump default emulator image to 1.5.52

### DIFF
--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DefaultEmulatorImage = "gcr.io/cloud-spanner-emulator/emulator:1.5.50"
+	DefaultEmulatorImage = "gcr.io/cloud-spanner-emulator/emulator:1.5.52"
 	DefaultProjectID     = "emulator-project"
 	DefaultInstanceID    = "emulator-instance"
 	DefaultDatabaseID    = "emulator-database"


### PR DESCRIPTION
## Summary

- bump `DefaultEmulatorImage` to `gcr.io/cloud-spanner-emulator/emulator:1.5.52`

## Validation

- `go build ./...`
- `TESTCONTAINERS_RYUK_DISABLED=true go test -v ./...`
- `golangci-lint run`
