### PR TITLE
Expose emulator gateway flags as Option helpers

### DIFF
--- a/gateway_flags_test.go
+++ b/gateway_flags_test.go
@@ -1,0 +1,107 @@
+package spanemuboost
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestGatewayFlagOptionsAppendExpectedFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opt  Option
+		want string
+	}{
+		{name: "EnableFaultInjection", opt: EnableFaultInjection(), want: "--enable_fault_injection"},
+		{name: "EnableLogRequests", opt: EnableLogRequests(), want: "--log_requests"},
+		{name: "EnableEmulatorStdoutCopy", opt: EnableEmulatorStdoutCopy(), want: "--copy_emulator_stdout"},
+		{name: "DisableQueryNullFilteredIndexCheck", opt: DisableQueryNullFilteredIndexCheck(), want: "--disable_query_null_filtered_index_check"},
+		{name: "WithMaxDatabasesPerInstance", opt: WithMaxDatabasesPerInstance(500), want: "--override_max_databases_per_instance=500"},
+		{name: "WithChangeStreamPartitionTokenAliveSeconds", opt: WithChangeStreamPartitionTokenAliveSeconds(7), want: "--override_change_stream_partition_token_alive_seconds=7"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			opts, err := applyOptions(tc.opt)
+			if err != nil {
+				t.Fatalf("applyOptions: %v", err)
+			}
+			if !slices.Contains(opts.gatewayFlags, tc.want) {
+				t.Fatalf("gatewayFlags = %v, want to contain %q", opts.gatewayFlags, tc.want)
+			}
+		})
+	}
+}
+
+func TestGatewayFlagOptionsAccumulate(t *testing.T) {
+	t.Parallel()
+	opts, err := applyOptions(
+		EnableFaultInjection(),
+		EnableLogRequests(),
+		WithMaxDatabasesPerInstance(200),
+	)
+	if err != nil {
+		t.Fatalf("applyOptions: %v", err)
+	}
+	want := []string{
+		"--enable_fault_injection",
+		"--log_requests",
+		"--override_max_databases_per_instance=200",
+	}
+	if !slices.Equal(opts.gatewayFlags, want) {
+		t.Fatalf("gatewayFlags = %v, want %v", opts.gatewayFlags, want)
+	}
+}
+
+func TestGatewayFlagOptionsRejectNonPositive(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		opt  Option
+	}{
+		{name: "WithMaxDatabasesPerInstance/zero", opt: WithMaxDatabasesPerInstance(0)},
+		{name: "WithMaxDatabasesPerInstance/negative", opt: WithMaxDatabasesPerInstance(-1)},
+		{name: "WithChangeStreamPartitionTokenAliveSeconds/zero", opt: WithChangeStreamPartitionTokenAliveSeconds(0)},
+		{name: "WithChangeStreamPartitionTokenAliveSeconds/negative", opt: WithChangeStreamPartitionTokenAliveSeconds(-5)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := applyOptions(tc.opt); err == nil {
+				t.Fatal("applyOptions: want error, got nil")
+			}
+		})
+	}
+}
+
+// TestOmniGuardrailRejectsGatewayFlags ensures the gateway-flag Option helpers
+// do not silently leak into Omni's start command. The guardrail must fire
+// unless DisableBackendGuardrails is set.
+func TestOmniGuardrailRejectsGatewayFlags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejected by default", func(t *testing.T) {
+		t.Parallel()
+		_, err := applyOmniOptions(EnableFaultInjection())
+		if err == nil {
+			t.Fatal("applyOmniOptions: want error, got nil")
+		}
+		if !strings.Contains(err.Error(), "--enable_fault_injection") {
+			t.Fatalf("error %q does not mention the rejected flag", err.Error())
+		}
+	})
+
+	t.Run("allowed when guardrails disabled", func(t *testing.T) {
+		t.Parallel()
+		opts, err := applyOmniOptions(EnableFaultInjection(), DisableBackendGuardrails())
+		if err != nil {
+			t.Fatalf("applyOmniOptions: %v", err)
+		}
+		if !slices.Contains(opts.gatewayFlags, "--enable_fault_injection") {
+			t.Fatalf("gatewayFlags = %v, want to contain --enable_fault_injection", opts.gatewayFlags)
+		}
+	})
+}

--- a/internal.go
+++ b/internal.go
@@ -34,10 +34,11 @@ type createdSchemaResources struct {
 const rollbackTimeout = 30 * time.Second
 
 func newEmulator(ctx context.Context, opts *emulatorOptions) (container *tcspanner.Container, teardown func(), err error) {
+	gatewayCmd := append([]string{"./gateway_main", "--hostname", "0.0.0.0"}, opts.gatewayFlags...)
 	containerCustomizers := []testcontainers.ContainerCustomizer{
 		tcspanner.WithProjectID(opts.projectID),
 		testcontainers.WithConfigModifier(func(config *dcontainer.Config) {
-			config.Cmd = []string{"./gateway_main", "--hostname", "0.0.0.0"}
+			config.Cmd = gatewayCmd
 		}),
 	}
 	containerCustomizers = append(containerCustomizers, opts.containerCustomizers...)

--- a/omni.go
+++ b/omni.go
@@ -207,6 +207,9 @@ func finalizeOmniOptions(opts *emulatorOptions) (*emulatorOptions, error) {
 	if !opts.disableCreateInstance && !opts.disableBackendGuardrails {
 		return nil, omniGuardrailError("instance auto-configuration is unsupported for Spanner Omni single-server because the built-in default instance cannot be created, updated, or deleted", "use the default behavior or EnableDatabaseAutoConfigOnly(), or DisableBackendGuardrails() to bypass this validation")
 	}
+	if len(opts.gatewayFlags) > 0 && !opts.disableBackendGuardrails {
+		return nil, omniGuardrailError(fmt.Sprintf("emulator gateway flag options are unsupported for Spanner Omni; got %v", opts.gatewayFlags), "remove the emulator-only Option helpers (e.g. EnableFaultInjection, EnableLogRequests), or DisableBackendGuardrails() to bypass this validation")
+	}
 	if opts.randomDatabaseID && opts.databaseID != "" {
 		return nil, fmt.Errorf("WithRandomDatabaseID() and WithDatabaseID() are mutually exclusive")
 	}

--- a/options.go
+++ b/options.go
@@ -55,6 +55,89 @@ func EnableFaultInjection() Option {
 	}
 }
 
+// EnableLogRequests enables gRPC request and response logging in the emulator
+// gateway (the emulator's --log_requests flag). Useful when debugging test
+// failures; output is written to the container's stdout.
+func EnableLogRequests() Option {
+	return func(opts *emulatorOptions) error {
+		opts.containerCustomizers = append(opts.containerCustomizers, testcontainers.WithConfigModifier(func(config *container.Config) {
+			config.Cmd = append(config.Cmd, "--log_requests")
+		}))
+		return nil
+	}
+}
+
+// EnableEmulatorStdoutCopy enables copying the emulator backend's stdout to
+// the gateway's stdout (the emulator's --copy_emulator_stdout flag). The
+// gateway already copies the backend's stderr by default; this option adds
+// the matching stdout stream for debugging.
+func EnableEmulatorStdoutCopy() Option {
+	return func(opts *emulatorOptions) error {
+		opts.containerCustomizers = append(opts.containerCustomizers, testcontainers.WithConfigModifier(func(config *container.Config) {
+			config.Cmd = append(config.Cmd, "--copy_emulator_stdout")
+		}))
+		return nil
+	}
+}
+
+// DisableQueryNullFilteredIndexCheck disables the emulator's safeguard that
+// rejects queries against NULL_FILTERED indexes (the emulator's
+// --disable_query_null_filtered_index_check flag).
+//
+// Production Spanner answers such queries; the emulator rejects them by
+// default because the result set can legitimately differ from a base-table
+// scan. Use this option only in tests that intentionally exercise reads
+// against NULL_FILTERED indexes and have accounted for that difference.
+func DisableQueryNullFilteredIndexCheck() Option {
+	return func(opts *emulatorOptions) error {
+		opts.containerCustomizers = append(opts.containerCustomizers, testcontainers.WithConfigModifier(func(config *container.Config) {
+			config.Cmd = append(config.Cmd, "--disable_query_null_filtered_index_check")
+		}))
+		return nil
+	}
+}
+
+// WithMaxDatabasesPerInstance overrides the emulator's maximum number of
+// databases per instance (the emulator's --override_max_databases_per_instance
+// flag). n must be positive.
+//
+// Per the upstream help text, the emulator only honors values greater than
+// Spanner's default limit (100); smaller values are ignored. If the
+// MAX_DATABASES_PER_INSTANCE environment variable is also set on the
+// container, it takes precedence over this flag.
+func WithMaxDatabasesPerInstance(n int) Option {
+	return func(opts *emulatorOptions) error {
+		if n <= 0 {
+			return fmt.Errorf("WithMaxDatabasesPerInstance: n must be > 0, got %d", n)
+		}
+		opts.containerCustomizers = append(opts.containerCustomizers, testcontainers.WithConfigModifier(func(config *container.Config) {
+			config.Cmd = append(config.Cmd, fmt.Sprintf("--override_max_databases_per_instance=%d", n))
+		}))
+		return nil
+	}
+}
+
+// WithChangeStreamPartitionTokenAliveSeconds overrides the alive time of
+// change stream partition tokens (the emulator's
+// --override_change_stream_partition_token_alive_seconds flag). seconds must
+// be positive.
+//
+// Per the upstream help text, the effective alive time becomes
+// seconds..2*seconds (the emulator's default is 20..40s, which differs from
+// production Spanner). This flag is emulator-only and has no effect on
+// production Spanner.
+func WithChangeStreamPartitionTokenAliveSeconds(seconds int) Option {
+	return func(opts *emulatorOptions) error {
+		if seconds <= 0 {
+			return fmt.Errorf("WithChangeStreamPartitionTokenAliveSeconds: seconds must be > 0, got %d", seconds)
+		}
+		opts.containerCustomizers = append(opts.containerCustomizers, testcontainers.WithConfigModifier(func(config *container.Config) {
+			config.Cmd = append(config.Cmd, fmt.Sprintf("--override_change_stream_partition_token_alive_seconds=%d", seconds))
+		}))
+		return nil
+	}
+}
+
 // WithClientOptionsForClient configures ClientOption for Clients.Client.
 func WithClientOptionsForClient(option ...option.ClientOption) Option {
 	return func(opts *emulatorOptions) error {

--- a/options.go
+++ b/options.go
@@ -7,7 +7,6 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
-	"github.com/moby/moby/api/types/container"
 	"github.com/testcontainers/testcontainers-go"
 	"google.golang.org/api/option"
 )
@@ -30,6 +29,11 @@ type emulatorOptions struct {
 	clientConfig           *spanner.ClientConfig // nil until finalizeOptions; guaranteed non-nil after
 	containerCustomizers   []testcontainers.ContainerCustomizer
 	clientOptionsForClient []option.ClientOption
+
+	// gatewayFlags accumulates extra arguments appended to the emulator
+	// gateway_main command line. They are emulator-specific; finalizeOmniOptions
+	// rejects them unless backend guardrails are disabled.
+	gatewayFlags []string
 }
 
 // Option configures spanemuboost runtime bootstrap behavior.
@@ -45,61 +49,42 @@ func WithContainerCustomizers(containerCustomizers ...testcontainers.ContainerCu
 	}
 }
 
-// EnableFaultInjection enables fault injection of Cloud Spanner Emulator.
+// EnableFaultInjection enables fault injection of Cloud Spanner Emulator
+// (the emulator's --enable_fault_injection flag). Emulator-only.
 func EnableFaultInjection() Option {
-	return func(opts *emulatorOptions) error {
-		opts.containerCustomizers = append(opts.containerCustomizers, testcontainers.WithConfigModifier(func(config *container.Config) {
-			config.Cmd = append(config.Cmd, "--enable_fault_injection")
-		}))
-		return nil
-	}
+	return appendGatewayFlag("--enable_fault_injection")
 }
 
 // EnableLogRequests enables gRPC request and response logging in the emulator
 // gateway (the emulator's --log_requests flag). Useful when debugging test
-// failures; output is written to the container's stdout.
+// failures; output is written to the container's stdout. Emulator-only.
 func EnableLogRequests() Option {
-	return func(opts *emulatorOptions) error {
-		opts.containerCustomizers = append(opts.containerCustomizers, testcontainers.WithConfigModifier(func(config *container.Config) {
-			config.Cmd = append(config.Cmd, "--log_requests")
-		}))
-		return nil
-	}
+	return appendGatewayFlag("--log_requests")
 }
 
 // EnableEmulatorStdoutCopy enables copying the emulator backend's stdout to
 // the gateway's stdout (the emulator's --copy_emulator_stdout flag). The
 // gateway already copies the backend's stderr by default; this option adds
-// the matching stdout stream for debugging.
+// the matching stdout stream for debugging. Emulator-only.
 func EnableEmulatorStdoutCopy() Option {
-	return func(opts *emulatorOptions) error {
-		opts.containerCustomizers = append(opts.containerCustomizers, testcontainers.WithConfigModifier(func(config *container.Config) {
-			config.Cmd = append(config.Cmd, "--copy_emulator_stdout")
-		}))
-		return nil
-	}
+	return appendGatewayFlag("--copy_emulator_stdout")
 }
 
 // DisableQueryNullFilteredIndexCheck disables the emulator's safeguard that
 // rejects queries against NULL_FILTERED indexes (the emulator's
-// --disable_query_null_filtered_index_check flag).
+// --disable_query_null_filtered_index_check flag). Emulator-only.
 //
 // Production Spanner answers such queries; the emulator rejects them by
 // default because the result set can legitimately differ from a base-table
 // scan. Use this option only in tests that intentionally exercise reads
 // against NULL_FILTERED indexes and have accounted for that difference.
 func DisableQueryNullFilteredIndexCheck() Option {
-	return func(opts *emulatorOptions) error {
-		opts.containerCustomizers = append(opts.containerCustomizers, testcontainers.WithConfigModifier(func(config *container.Config) {
-			config.Cmd = append(config.Cmd, "--disable_query_null_filtered_index_check")
-		}))
-		return nil
-	}
+	return appendGatewayFlag("--disable_query_null_filtered_index_check")
 }
 
 // WithMaxDatabasesPerInstance overrides the emulator's maximum number of
 // databases per instance (the emulator's --override_max_databases_per_instance
-// flag). n must be positive.
+// flag). n must be positive. Emulator-only.
 //
 // Per the upstream help text, the emulator only honors values greater than
 // Spanner's default limit (100); smaller values are ignored. If the
@@ -110,9 +95,7 @@ func WithMaxDatabasesPerInstance(n int) Option {
 		if n <= 0 {
 			return fmt.Errorf("WithMaxDatabasesPerInstance: n must be > 0, got %d", n)
 		}
-		opts.containerCustomizers = append(opts.containerCustomizers, testcontainers.WithConfigModifier(func(config *container.Config) {
-			config.Cmd = append(config.Cmd, fmt.Sprintf("--override_max_databases_per_instance=%d", n))
-		}))
+		opts.gatewayFlags = append(opts.gatewayFlags, fmt.Sprintf("--override_max_databases_per_instance=%d", n))
 		return nil
 	}
 }
@@ -120,7 +103,7 @@ func WithMaxDatabasesPerInstance(n int) Option {
 // WithChangeStreamPartitionTokenAliveSeconds overrides the alive time of
 // change stream partition tokens (the emulator's
 // --override_change_stream_partition_token_alive_seconds flag). seconds must
-// be positive.
+// be positive. Emulator-only.
 //
 // Per the upstream help text, the effective alive time becomes
 // seconds..2*seconds (the emulator's default is 20..40s, which differs from
@@ -131,9 +114,14 @@ func WithChangeStreamPartitionTokenAliveSeconds(seconds int) Option {
 		if seconds <= 0 {
 			return fmt.Errorf("WithChangeStreamPartitionTokenAliveSeconds: seconds must be > 0, got %d", seconds)
 		}
-		opts.containerCustomizers = append(opts.containerCustomizers, testcontainers.WithConfigModifier(func(config *container.Config) {
-			config.Cmd = append(config.Cmd, fmt.Sprintf("--override_change_stream_partition_token_alive_seconds=%d", seconds))
-		}))
+		opts.gatewayFlags = append(opts.gatewayFlags, fmt.Sprintf("--override_change_stream_partition_token_alive_seconds=%d", seconds))
+		return nil
+	}
+}
+
+func appendGatewayFlag(flag string) Option {
+	return func(opts *emulatorOptions) error {
+		opts.gatewayFlags = append(opts.gatewayFlags, flag)
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary

- Add five `Option` helpers that surface `gateway_main` flags as first-class API, so callers no longer need to hand-roll `testcontainers.WithConfigModifier` for common runtime tweaks.
- Each helper mirrors the existing `EnableFaultInjection` shape (append a `WithConfigModifier` that extends `config.Cmd`), and the `With*` variants validate that their numeric argument is positive.

| Helper | Underlying flag | Use case |
| --- | --- | --- |
| `EnableLogRequests()` | `--log_requests` | Debugging gRPC traffic in tests |
| `EnableEmulatorStdoutCopy()` | `--copy_emulator_stdout` | Symmetric with the gateway's default stderr copy |
| `DisableQueryNullFilteredIndexCheck()` | `--disable_query_null_filtered_index_check` | Tests that intentionally read from NULL_FILTERED indexes |
| `WithMaxDatabasesPerInstance(n)` | `--override_max_databases_per_instance=<n>` | Test fixtures that create many databases per instance |
| `WithChangeStreamPartitionTokenAliveSeconds(s)` | `--override_change_stream_partition_token_alive_seconds=<s>` | Realistic change-stream tests |

Reference: `docker run --rm gcr.io/cloud-spanner-emulator/emulator:1.5.53 ./gateway_main --help`.

Skipped flags: `--copy_emulator_stderr` (on by default), `--grpc_binary` / `--grpc_port` / `--hostname` / `--http_port` (container-internal), `--notices` (print-and-exit info dump), `--enable_fault_injection` (already exposed).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] `go test -race ./...`
- [ ] `golangci-lint run`
- [ ] Manual smoke check: start an emulator with `EnableLogRequests()` and confirm request logs appear in container output