### PR TITLE
Add Podman smoke CI

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,2 @@
+code_review:
+  comment_severity_threshold: HIGH

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,3 +39,38 @@ jobs:
 
       - name: Run Omni smoke tests
         run: make omni-smoke
+
+  podman-smoke:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run smoke tests with rootless Podman
+        run: |
+          export XDG_RUNTIME_DIR="${RUNNER_TEMP}/podman-run"
+          export DOCKER_HOST="unix://${XDG_RUNTIME_DIR}/podman.sock"
+          export SPANEMUBOOST_TESTCONTAINERS_PROVIDER=podman
+          export TESTCONTAINERS_RYUK_DISABLED=true
+
+          mkdir -p "$XDG_RUNTIME_DIR"
+          chmod 700 "$XDG_RUNTIME_DIR"
+          podman --version
+          podman system service --time=0 "$DOCKER_HOST" &
+          podman_service_pid=$!
+          trap 'kill "$podman_service_pid" 2>/dev/null || true' EXIT
+          for _ in {1..30}; do
+            if podman --url "$DOCKER_HOST" info; then
+              make emulator-smoke
+              make omni-smoke
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Podman API service did not become ready" >&2
+          exit 1

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
-.PHONY: test lint omni-smoke
+.PHONY: test lint emulator-smoke omni-smoke
 
 # Keep this as an explicit test-name list rather than a compact grouped regex so
-# CI selection stays easy to audit when Omni smoke coverage changes. Match either
-# the top-level test name or one of its subtests.
+# CI selection stays easy to audit when smoke coverage changes. Match either the
+# top-level test name or one of its subtests.
+EMULATOR_SMOKE_TEST_PATTERN = ^(TestRunEmulatorWithClients|TestSetupEmulatorAndSetupClients|TestRuntimePlatformWithStartedRuntime|TestLazyRuntimeEmulatorWithSetupClients)($$|/)
 OMNI_SMOKE_TEST_PATTERN = ^(TestRunOmni|TestRunOmniWithClients|TestOpenOmniClients|TestOpenOmniClientsReuseDefaultDatabase|TestOpenOmniClientsAllowDatabaseOverride|TestSetupClientsWithOmni|TestLazyRuntimeWithOmni)($$|/)
 
 test:
 	go test -v ./...
 lint:
 	golangci-lint run
+emulator-smoke:
+	go test -v -race -count=1 -shuffle=on -p=1 -parallel=1 -run '$(EMULATOR_SMOKE_TEST_PATTERN)' ./...
 omni-smoke:
 	SPANEMUBOOST_ENABLE_OMNI_TESTS=1 go test -v -race -count=1 -shuffle=on -p=1 -parallel=1 -run '$(OMNI_SMOKE_TEST_PATTERN)' ./...

--- a/docs/omni-runtime-environments.md
+++ b/docs/omni-runtime-environments.md
@@ -164,6 +164,42 @@ The test logs showed repeated `spanner_server` crashes with `segmentation fault`
 `bus error`, and `aborted` before readiness. Ryuk cleaned up the failed
 containers and volumes after the test exited.
 
+## GitHub Actions rootless Podman
+
+GitHub-hosted Ubuntu runners include Podman. For Testcontainers-Go, start a
+rootless Podman API service and point `DOCKER_HOST` at that socket. Disable Ryuk
+because the hosted runner is ephemeral and the rootless Podman path does not
+provide the privileged reaper setup used by local rootful Podman. Run both the
+default emulator smoke tests and the Omni smoke tests so CI covers the
+Testcontainers-Go Spanner emulator module path as well as the custom Omni
+container path.
+
+```sh
+export XDG_RUNTIME_DIR="${RUNNER_TEMP}/podman-run"
+export DOCKER_HOST="unix://${XDG_RUNTIME_DIR}/podman.sock"
+export TESTCONTAINERS_RYUK_DISABLED=true
+export SPANEMUBOOST_TESTCONTAINERS_PROVIDER=podman
+
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+podman system service --time=0 "$DOCKER_HOST" &
+podman_ready=false
+for _ in {1..30}; do
+  if podman --url "$DOCKER_HOST" info; then
+    podman_ready=true
+    break
+  fi
+  sleep 1
+done
+if [ "$podman_ready" != true ]; then
+  echo "Podman API service did not become ready" >&2
+  exit 1
+fi
+
+make emulator-smoke
+make omni-smoke
+```
+
 ## Quickstart probe
 
 Use this to recheck a runtime without running Go tests:
@@ -217,3 +253,4 @@ For Testcontainers-Go failures, also check:
 - Testcontainers-Go with Podman: https://golang.testcontainers.org/system_requirements/using_podman/
 - Testcontainers-Go configuration: https://golang.testcontainers.org/features/configuration/
 - Podman machine: https://docs.podman.io/en/latest/markdown/podman-machine.1.html
+- GitHub Actions Ubuntu runner image: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md


### PR DESCRIPTION
## Summary
- configure Gemini Code Review to comment only on HIGH severity and above
- add an emulator smoke target for the default Cloud Spanner Emulator path
- add a GitHub Actions smoke job that runs emulator and Omni checks through rootless Podman on ubuntu-24.04
- document the GitHub Actions Podman environment used by the CI job

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p) }; puts "yaml ok"' .github/workflows/go.yml .gemini/config.yaml`
- `git diff --check`
- `make -n emulator-smoke`
- `make -n omni-smoke`
- `go test -list '^(TestRunEmulatorWithClients|TestSetupEmulatorAndSetupClients|TestRuntimePlatformWithStartedRuntime|TestLazyRuntimeEmulatorWithSetupClients)($|/)' ./...`
- GitHub Actions on PR #57: `build-and-test`, `lint`, `omni-smoke`, and `podman-smoke` passed

`actionlint` is not installed locally, so the workflow syntax is left to GitHub Actions validation.
