### PR TITLE
Improve shared runtime documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,33 @@ func TestFoo(t *testing.T) {
 
 For non-test usage (e.g. embedding the emulator in an application where the `testing` package is unavailable), see runnable examples on [pkg.go.dev](https://pkg.go.dev/github.com/apstndb/spanemuboost#pkg-examples).
 
+### Shared runtime, database-per-case
+
+For many independent test or validation cases, prefer one shared backend runtime
+and one database per case. That is the recommended shape for the emulator, and
+it is even more important for Omni because each Omni runtime owns a memory-heavy
+container.
+
+Use `NewLazyRuntime` plus `SetupClients` or `OpenClients` when cases should
+share a runtime lazily. Use `WithRandomDatabaseID()` for per-case isolation. See
+`ExampleNewLazyRuntime_validationCases` on
+[pkg.go.dev](https://pkg.go.dev/github.com/apstndb/spanemuboost#pkg-examples)
+for a validation-harness shape that composes shared and case-specific setup, and
+separates setup failures from candidate statement results.
+
+Random database IDs do not enable schema teardown on `Clients.Close()` by
+default. The databases disappear when the runtime container is closed. For
+long-lived shared runtimes, use `ForceSchemaTeardown()` or explicit cleanup if
+database accumulation matters.
+
+| Need | Entry point | Starts a new runtime container? |
+|---|---|---|
+| One test owns runtime and clients | `SetupWithClients(t, backend, ...)` | Yes |
+| Non-test code owns runtime and clients | `RunWithClients(ctx, backend, ...)` | Yes |
+| Many tests share one runtime with `testing.TB` cleanup | `NewLazyRuntime(backend, ...)` + `SetupClients` | Once, on first use |
+| Many cases need explicit `context.Context` or manual client cleanup | `NewLazyRuntime(backend, ...)` + `OpenClients` | Once, on first use |
+| Eager runtime startup with multiple databases | `Run(ctx, backend, ...)` + `OpenClients` | Once, when `Run` is called |
+
 ### Spanner Omni (experimental)
 
 `Setup`, `Run`, `RunWithClients`, and `SetupWithClients` with `BackendOmni` start a Spanner Omni single-server container and use the public Spanner gRPC API on port `15000` for database creation, DDL application, DML setup, and managed client creation. This path is intended for integration tests that want a real Omni runtime without depending on the emulator.
@@ -53,6 +80,11 @@ func TestOmni(t *testing.T) {
     if err != nil { t.Fatal(err) }
 }
 ```
+
+For Omni, use databases as the normal isolation unit. Do not use random project
+or instance IDs for ordinary test isolation; the single-server deployment uses
+fixed project and instance IDs. Use `WithRandomDatabaseID()` and share the
+runtime with `NewLazyRuntime(BackendOmni, ...)` when many cases are involved.
 
 | Omni caveat | Detail |
 |---|---|

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,15 @@
+// Package spanemuboost starts Cloud Spanner Emulator and experimental Spanner
+// Omni runtimes for tests, then bootstraps instances, databases, schema, and
+// Spanner clients.
+//
+// The emulator path is the default and stable path. Use
+// [SetupEmulatorWithClients] for simple tests. For many independent cases
+// against either backend, share one runtime with [NewLazyRuntime] and create one
+// database per case with [WithRandomDatabaseID].
+//
+// The Omni path uses [BackendOmni] through the backend-neutral APIs such as
+// [Setup], [Run], [SetupWithClients], [RunWithClients], [OpenClients],
+// [SetupClients], and [NewLazyRuntime]. Omni support is experimental. The
+// shared-runtime pattern is especially important for Omni because each started
+// Omni runtime owns one Spanner Omni container.
+package spanemuboost

--- a/docs/omni-runtime-environments.md
+++ b/docs/omni-runtime-environments.md
@@ -1,7 +1,7 @@
 # Runtime environments for Spanner Omni tests
 
-This note records the runtime settings that are useful for running or
-rechecking `spanemuboost` Spanner Omni tests on macOS arm64.
+This note records runtime settings that are useful for running or rechecking
+`spanemuboost` Spanner Omni tests on local runtimes and GitHub Actions.
 
 Last checked: 2026-05-19.
 

--- a/example_test.go
+++ b/example_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"cloud.google.com/go/spanner"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 
 	"github.com/apstndb/spanemuboost"
 )
@@ -150,6 +152,139 @@ func ExampleLazyRuntime() {
 		log.Fatalln(err)
 	}
 	// Output: {fields: [type:{code:INT64}], values: [string_value:"1"]}
+}
+
+func ExampleNewLazyRuntime_validationCases() {
+	ctx := context.Background()
+	// LazyRuntime shares one backend container across all cases. The same
+	// database-per-case loop works with BackendOmni; omit
+	// EnableInstanceAutoConfigOnly there because Omni uses its built-in instance.
+	lazy := spanemuboost.NewLazyRuntime(
+		spanemuboost.BackendEmulator,
+		spanemuboost.EnableInstanceAutoConfigOnly(),
+	)
+	defer func() {
+		if err := lazy.Close(); err != nil {
+			log.Printf("failed to close runtime: %v", err)
+		}
+	}()
+
+	baseDDLs := []string{
+		"CREATE TABLE Singers (SingerId INT64, Name STRING(MAX)) PRIMARY KEY (SingerId)",
+	}
+	baseDMLs := []string{
+		"INSERT INTO Singers (SingerId, Name) VALUES (1, 'Marc Richards')",
+	}
+	cases := []struct {
+		name      string
+		setupDDLs []string
+		ddl       string
+		dml       spanner.Statement
+		query     string
+	}{
+		{
+			name: "ddl",
+			ddl:  "CREATE TABLE Albums (SingerId INT64, AlbumId INT64) PRIMARY KEY (SingerId, AlbumId)",
+		},
+		{
+			name: "dml",
+			setupDDLs: []string{
+				"CREATE TABLE Albums (SingerId INT64, AlbumId INT64, Title STRING(MAX)) PRIMARY KEY (SingerId, AlbumId)",
+			},
+			dml: spanner.NewStatement("INSERT INTO Albums (SingerId, AlbumId, Title) VALUES (1, 1, 'Total Junk')"),
+		},
+		{
+			name:  "query",
+			query: "SELECT Name FROM Singers WHERE SingerId = 1",
+		},
+	}
+
+	for _, tc := range cases {
+		// Setup options replace previous values, so compose shared setup and
+		// case-specific setup before calling WithSetupDDLs.
+		setupDDLs := append([]string{}, baseDDLs...)
+		setupDDLs = append(setupDDLs, tc.setupDDLs...)
+
+		// WithRandomDatabaseID isolates cases without starting another backend
+		// container. For Omni, random project and instance IDs are not the
+		// normal isolation mechanism.
+		clients, err := spanemuboost.OpenClients(ctx, lazy,
+			spanemuboost.WithRandomDatabaseID(),
+			spanemuboost.WithSetupDDLs(setupDDLs),
+			spanemuboost.WithSetupRawDMLs(baseDMLs),
+		)
+		if err != nil {
+			log.Printf("%s: SETUP_INVALID: %v", tc.name, err)
+			continue
+		}
+
+		func() {
+			defer func() {
+				if err := clients.Close(); err != nil {
+					log.Printf("%s: close clients: %v", tc.name, err)
+				}
+			}()
+
+			var err error
+			switch {
+			case tc.ddl != "":
+				// Candidate DDL is executed after setup so setup failures and
+				// candidate failures can be reported separately.
+				op, opErr := clients.DatabaseClient.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
+					Database:   clients.DatabasePath(),
+					Statements: []string{tc.ddl},
+				})
+				if opErr != nil {
+					err = opErr
+				} else {
+					err = op.Wait(ctx)
+				}
+			case tc.dml.SQL != "":
+				_, err = clients.Client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+					_, err := txn.Update(ctx, tc.dml)
+					return err
+				})
+			case tc.query != "":
+				iter := clients.Client.Single().Query(ctx, spanner.NewStatement(tc.query))
+				err = iter.Do(func(*spanner.Row) error { return nil })
+			}
+			if err != nil {
+				log.Printf("%s: INVALID: %v", tc.name, err)
+				return
+			}
+			log.Printf("%s: VALID", tc.name)
+		}()
+	}
+}
+
+func ExampleRecommendedOmniClientConfig_externalClient() {
+	if os.Getenv("SPANEMUBOOST_ENABLE_OMNI_TESTS") != "1" {
+		return
+	}
+
+	ctx := context.Background()
+	runtime, err := spanemuboost.Run(ctx, spanemuboost.BackendOmni,
+		spanemuboost.WithRandomDatabaseID(),
+	)
+	if err != nil {
+		log.Printf("failed to start Omni runtime: %v", err)
+		return
+	}
+	defer runtime.Close() //nolint:errcheck
+
+	client, err := spanner.NewClientWithConfig(
+		ctx,
+		runtime.DatabasePath(),
+		spanemuboost.RecommendedOmniClientConfig(),
+		runtime.ClientOptions()...,
+	)
+	if err != nil {
+		log.Printf("failed to create Omni client: %v", err)
+		return
+	}
+	defer client.Close()
+
+	_ = client
 }
 
 // Deprecated examples kept for backward compatibility testing.


### PR DESCRIPTION
## Summary

- add package-level godoc for backend-neutral runtime usage
- document the shared runtime, database-per-case pattern and random database teardown behavior
- add pkg.go.dev examples for validation-case workflows and external Omni clients
- clarify Omni runtime-environment notes for local runtimes and CI smoke checks

## Validation

- `gofmt -w example_test.go`
- `go test -run '^$' ./...`
- `git diff --check`
- `go doc .`
- `review-router --source staged --ignore-untracked --max-selected 2`
  - reviewed with `cursor-agent-composer-2-fast` and `gemini-flash`
  - addressed cleanup, per-case setup, teardown-semantics, and emulator bootstrap feedback from review
