### PR TITLE
Bump Cloud Spanner emulator to 1.5.54

### DIFF
--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DefaultEmulatorImage = "gcr.io/cloud-spanner-emulator/emulator:1.5.52"
+	DefaultEmulatorImage = "gcr.io/cloud-spanner-emulator/emulator:1.5.54"
 	DefaultProjectID     = "emulator-project"
 	DefaultInstanceID    = "emulator-instance"
 	DefaultDatabaseID    = "emulator-database"


### PR DESCRIPTION
## Summary

- bump `DefaultEmulatorImage` from `gcr.io/cloud-spanner-emulator/emulator:1.5.52` to `1.5.54`

## Notes

- Verified public semver tags with:
  - `gcloud container images list-tags gcr.io/cloud-spanner-emulator/emulator --filter='tags~^1\\.5\\.' --limit=50 --sort-by=~TAGS --format=json`
- `1.5.54` is currently tagged together with `latest`.

## Validation

- `go test -run '^$' ./...`
- `git diff --check`
- `env DOCKER_HOST="unix://${HOME}/.colima/default/docker.sock" TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock make emulator-smoke`
