### PR TITLE
Bump Spanner Omni image to 2026.r1-beta.1

### DIFF
--- a/docs/omni-runtime-environments.md
+++ b/docs/omni-runtime-environments.md
@@ -129,7 +129,7 @@ ready. The quickstart container was started with:
 podman volume create spanemuboost-omni-58
 podman run -d --network host --name spanemuboost-omni-58 \
   -v spanemuboost-omni-58:/spanner \
-  us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r1-beta \
+  us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r1-beta.1 \
   start-single-server
 ```
 
@@ -207,7 +207,7 @@ Use this to recheck a runtime without running Go tests:
 ```sh
 podman volume create spanner
 podman run -d --network host --name spanneromni -v spanner:/spanner \
-  us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r1-beta \
+  us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r1-beta.1 \
   start-single-server
 podman logs --tail 120 spanneromni
 podman exec spanneromni /google/spanner/bin/spanner databases create-sample-db retail --database-name=retail-sample

--- a/omni.go
+++ b/omni.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultOmniImage      = "us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r1-beta"
+	defaultOmniImage      = "us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r1-beta.1"
 	defaultOmniProjectID  = "default"
 	defaultOmniInstanceID = "default"
 )


### PR DESCRIPTION
## Summary
- Update the default Spanner Omni container image tag from `2026.r1-beta` to `2026.r1-beta.1`, matching the canonical release on the [Spanner Omni download page](https://docs.cloud.google.com/spanner-omni/download) (April 22, 2026).
- Refresh copy-paste image references in `docs/omni-runtime-environments.md`.

## Test plan
- [x] `go test -run '^$' ./...`
- [x] `git diff --check`
- [ ] CI `omni-smoke` (pulls the updated image on merge)


Made with [Cursor](https://cursor.com)