### PR TITLE
Add external Omni endpoint attachment and serve CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,12 @@ published endpoint:
 
 ```sh
 spanemuboost serve omni --endpoint-file /tmp/omni-endpoint.json
+spanemuboost stop --endpoint-file /tmp/omni-endpoint.json
 ```
+
+The endpoint file is owned by `serve`: it is written on startup (including the
+serve process PID for lifecycle management) and removed on exit. Unset
+`SPANEMUBOOST_ENDPOINT_FILE` after stopping the lifecycle manager.
 
 In another shell:
 
@@ -178,9 +183,8 @@ and are rejected by Omni guardrails unless callers use
 `DisableBackendGuardrails()` on a programmatic runtime constructor.
 
 `[AttachedRuntime.Close]` is a no-op because the lifecycle manager owns the
-container. Stop the `serve` process to tear down the shared runtime. The
-endpoint file is removed when `serve` exits; unset `SPANEMUBOOST_ENDPOINT_FILE`
-after stopping the lifecycle manager.
+container. Stop the shared runtime with `spanemuboost stop` or by stopping the
+`serve` process directly.
 
 `Run`, `RunWithClients`, `Setup`, `SetupWithClients`, `OpenClients`, `SetupClients`, `RuntimePlatform`, and `NewLazyRuntime` work across emulator and Omni. This backend-neutral API surface is the primary stable entry point; only the `BackendOmni` backend and its specific behaviors are considered experimental. Omni does not add separate exported startup or client-opening helpers.
 

--- a/README.md
+++ b/README.md
@@ -170,11 +170,17 @@ clients, err := spanemuboost.OpenClients(ctx, runtime,
 |---|---|
 | `SPANEMUBOOST_ENDPOINT_FILE` | JSON file written by `spanemuboost serve` |
 | `SPANEMUBOOST_OMNI_URI` | Direct Omni gRPC endpoint (`host:port`) |
-| `SPANEMUBOOST_OMNI_PROJECT_ID` | Optional project override (default `default`) |
-| `SPANEMUBOOST_OMNI_INSTANCE_ID` | Optional instance override (default `default`) |
+| `SPANEMUBOOST_EMULATOR_URI` | Direct emulator gRPC endpoint (`host:port`) |
+
+When attaching to Omni via `SPANEMUBOOST_OMNI_URI`, project and instance IDs
+default to `default`. Non-default IDs require the running Omni instance to match
+and are rejected by Omni guardrails unless callers use
+`DisableBackendGuardrails()` on a programmatic runtime constructor.
 
 `[AttachedRuntime.Close]` is a no-op because the lifecycle manager owns the
-container. Stop the `serve` process to tear down the shared runtime.
+container. Stop the `serve` process to tear down the shared runtime. The
+endpoint file is removed when `serve` exits; unset `SPANEMUBOOST_ENDPOINT_FILE`
+after stopping the lifecycle manager.
 
 `Run`, `RunWithClients`, `Setup`, `SetupWithClients`, `OpenClients`, `SetupClients`, `RuntimePlatform`, and `NewLazyRuntime` work across emulator and Omni. This backend-neutral API surface is the primary stable entry point; only the `BackendOmni` backend and its specific behaviors are considered experimental. Omni does not add separate exported startup or client-opening helpers.
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,50 @@ func TestSharedHelpers(t *testing.T) {
 }
 ```
 
+### Reusing a long-lived Omni runtime
+
+Starting Spanner Omni through testcontainers is slow because each runtime pulls
+and boots a memory-heavy container. For local development and repeated test
+runs, start Omni once with the `spanemuboost` CLI and attach clients to the
+published endpoint:
+
+```sh
+spanemuboost serve omni --endpoint-file /tmp/omni-endpoint.json
+```
+
+In another shell:
+
+```sh
+export SPANEMUBOOST_ENDPOINT_FILE=/tmp/omni-endpoint.json
+export SPANEMUBOOST_ENABLE_OMNI_TESTS=1
+go test -p=1 -parallel=1 ./...
+```
+
+Client code can use [NewLazyRuntimeOptionalEndpoint] to keep the existing
+testcontainers path while automatically attaching when endpoint env vars are
+set, or [NewAttachedRuntimeFromEnv] for explicit attachment:
+
+```go
+runtime, err := spanemuboost.NewAttachedRuntimeFromEnv()
+if err != nil {
+    runtime = spanemuboost.NewLazyRuntime(spanemuboost.BackendOmni)
+}
+clients, err := spanemuboost.OpenClients(ctx, runtime,
+    spanemuboost.WithRandomDatabaseID(),
+    spanemuboost.WithSetupDDLs(ddls),
+)
+```
+
+| Variable | Purpose |
+|---|---|
+| `SPANEMUBOOST_ENDPOINT_FILE` | JSON file written by `spanemuboost serve` |
+| `SPANEMUBOOST_OMNI_URI` | Direct Omni gRPC endpoint (`host:port`) |
+| `SPANEMUBOOST_OMNI_PROJECT_ID` | Optional project override (default `default`) |
+| `SPANEMUBOOST_OMNI_INSTANCE_ID` | Optional instance override (default `default`) |
+
+`[AttachedRuntime.Close]` is a no-op because the lifecycle manager owns the
+container. Stop the `serve` process to tear down the shared runtime.
+
 `Run`, `RunWithClients`, `Setup`, `SetupWithClients`, `OpenClients`, `SetupClients`, `RuntimePlatform`, and `NewLazyRuntime` work across emulator and Omni. This backend-neutral API surface is the primary stable entry point; only the `BackendOmni` backend and its specific behaviors are considered experimental. Omni does not add separate exported startup or client-opening helpers.
 
 Use `RuntimePlatform(ctx, runtime)` when you want to surface the actual resolved container platform for a package-provided runtime handle without downcasting back to `*Emulator`. Depending on what metadata the underlying runtime exposes, that may be an `os/arch` string such as `linux/amd64`, a variant-qualified string such as `linux/arm64/v8`, or an OS-only value such as `linux`.

--- a/README.md
+++ b/README.md
@@ -151,14 +151,14 @@ export SPANEMUBOOST_ENABLE_OMNI_TESTS=1
 go test -p=1 -parallel=1 ./...
 ```
 
-Client code can use [NewLazyRuntimeOptionalEndpoint] to keep the existing
+Client code can use [NewLazyRuntimeFromEnvOrStart] to keep the existing
 testcontainers path while automatically attaching when endpoint env vars are
 set, or [NewAttachedRuntimeFromEnv] for explicit attachment:
 
 ```go
-runtime, err := spanemuboost.NewAttachedRuntimeFromEnv()
+runtime, err := spanemuboost.NewLazyRuntimeFromEnvOrStart(spanemuboost.BackendOmni)
 if err != nil {
-    runtime = spanemuboost.NewLazyRuntime(spanemuboost.BackendOmni)
+    log.Fatal(err)
 }
 clients, err := spanemuboost.OpenClients(ctx, runtime,
     spanemuboost.WithRandomDatabaseID(),

--- a/attached.go
+++ b/attached.go
@@ -21,11 +21,11 @@ type AttachedRuntime struct {
 func (*AttachedRuntime) spanemuboostRuntime() {}
 
 // NewAttachedRuntime connects to endpoint without starting a container.
-func NewAttachedRuntime(endpoint Endpoint) (*AttachedRuntime, error) {
+func NewAttachedRuntime(endpoint Endpoint, options ...Option) (*AttachedRuntime, error) {
 	if err := endpoint.validate(); err != nil {
 		return nil, err
 	}
-	opts, err := finalizeAttachedOptions(endpoint)
+	opts, err := finalizeAttachedOptions(endpoint, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -38,12 +38,12 @@ func NewAttachedRuntime(endpoint Endpoint) (*AttachedRuntime, error) {
 
 // NewAttachedRuntimeFromEnv is a convenience wrapper around [LoadEndpoint] and
 // [NewAttachedRuntime].
-func NewAttachedRuntimeFromEnv() (*AttachedRuntime, error) {
+func NewAttachedRuntimeFromEnv(options ...Option) (*AttachedRuntime, error) {
 	endpoint, err := LoadEndpoint()
 	if err != nil {
 		return nil, err
 	}
-	return NewAttachedRuntime(endpoint)
+	return NewAttachedRuntime(endpoint, options...)
 }
 
 // NewLazyRuntimeFromEnvOrStart returns a [LazyRuntime] that attaches to an
@@ -76,16 +76,25 @@ func NewLazyRuntimeOptionalEndpoint(backend Backend, options ...Option) (*LazyRu
 	return NewLazyRuntimeFromEnvOrStart(backend, options...)
 }
 
-func finalizeAttachedOptions(endpoint Endpoint) (*emulatorOptions, error) {
+func finalizeAttachedOptions(endpoint Endpoint, options ...Option) (*emulatorOptions, error) {
 	base := &emulatorOptions{
 		projectID:             endpoint.ProjectID,
 		instanceID:            endpoint.InstanceID,
 		disableCreateInstance: true,
 	}
+	var err error
 	switch endpoint.Backend {
 	case BackendOmni:
+		base, err = applyOmniOptionsWithBase(base, options...)
+		if err != nil {
+			return nil, err
+		}
 		return finalizeOmniOptions(base)
 	case BackendEmulator:
+		base, err = applyOptionsWithBase(base, options...)
+		if err != nil {
+			return nil, err
+		}
 		return finalizeOptions(base)
 	default:
 		return nil, fmt.Errorf("unsupported backend %q", endpoint.Backend)

--- a/attached.go
+++ b/attached.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"cloud.google.com/go/spanner"
 	"google.golang.org/api/option"
 	"google.golang.org/api/option/internaloption"
 	"google.golang.org/grpc"
@@ -47,21 +48,22 @@ func NewAttachedRuntimeFromEnv(options ...Option) (*AttachedRuntime, error) {
 }
 
 // NewLazyRuntimeFromEnvOrStart returns a [LazyRuntime] that attaches to an
-// external endpoint when one is configured in the environment. When no endpoint
-// env vars are set, it defers container startup until first use. When endpoint
-// env vars are set but [LoadEndpoint] fails, it returns an error instead of
-// falling back to cold start.
+// external endpoint when one is configured for the requested backend. When no
+// matching endpoint env vars are set, it defers container startup until first
+// use. When endpoint env vars are set but [LoadEndpointForBackend] fails, it
+// returns an error instead of falling back to cold start.
+//
+// Options passed to the constructor apply to both cold-start and attach paths.
+// Database bootstrap options such as [WithRandomDatabaseID] and [WithSetupDDLs]
+// are honored when [OpenClients] or [SetupClients] runs against the lazy handle.
 func NewLazyRuntimeFromEnvOrStart(backend Backend, options ...Option) (*LazyRuntime, error) {
 	lr := NewLazyRuntime(backend, options...)
-	if !endpointEnvConfigured() {
+	if !EndpointConfiguredForBackend(backend) {
 		return lr, nil
 	}
-	endpoint, err := LoadEndpoint()
+	endpoint, err := LoadEndpointForBackend(backend)
 	if err != nil {
 		return nil, err
-	}
-	if endpoint.Backend != backend {
-		return nil, fmt.Errorf("spanemuboost: configured endpoint backend %q does not match requested backend %q", endpoint.Backend, backend)
 	}
 	lr.attachedEndpoint = &endpoint
 	return lr, nil
@@ -90,6 +92,9 @@ func (a *AttachedRuntime) URI() string {
 	return a.uri
 }
 
+// ClientOptions returns transport options for the attached backend. Options
+// passed via [WithClientOptionsForClient] are applied in [OpenClients] and
+// [SetupClients], not here.
 func (a *AttachedRuntime) ClientOptions() []option.ClientOption {
 	if a == nil {
 		return nil
@@ -158,11 +163,28 @@ func (a *AttachedRuntime) inheritedOptions(options ...Option) (*emulatorOptions,
 		return nil, fmt.Errorf("spanemuboost: attached runtime or options is nil")
 	}
 	base := inheritedRuntimeOptions(a.opts)
+	preserveAttachedBootstrapOptions(base, a.opts)
+	if len(options) == 0 {
+		return base, nil
+	}
 	switch a.backend {
 	case BackendOmni:
 		return applyOmniOptionsWithBase(base, options...)
 	default:
 		return applyOptionsWithBase(base, options...)
+	}
+}
+
+func preserveAttachedBootstrapOptions(base, source *emulatorOptions) {
+	if !source.disableCreateDatabase {
+		base.disableCreateDatabase = false
+	}
+	base.randomDatabaseID = source.randomDatabaseID
+	if len(source.setupDDLs) > 0 {
+		base.setupDDLs = append([]string(nil), source.setupDDLs...)
+	}
+	if len(source.setupDMLs) > 0 {
+		base.setupDMLs = append([]spanner.Statement(nil), source.setupDMLs...)
 	}
 }
 

--- a/attached.go
+++ b/attached.go
@@ -67,35 +67,17 @@ func NewLazyRuntimeFromEnvOrStart(backend Backend, options ...Option) (*LazyRunt
 	return lr, nil
 }
 
-// NewLazyRuntimeOptionalEndpoint returns a [LazyRuntime] that attaches to an
-// external endpoint when one is configured in the environment. Otherwise it
-// starts a container on first use, preserving the existing testcontainers path.
-//
-// Deprecated: use [NewLazyRuntimeFromEnvOrStart] to handle endpoint load errors.
-func NewLazyRuntimeOptionalEndpoint(backend Backend, options ...Option) (*LazyRuntime, error) {
-	return NewLazyRuntimeFromEnvOrStart(backend, options...)
-}
-
 func finalizeAttachedOptions(endpoint Endpoint, options ...Option) (*emulatorOptions, error) {
 	base := &emulatorOptions{
 		projectID:             endpoint.ProjectID,
 		instanceID:            endpoint.InstanceID,
 		disableCreateInstance: true,
 	}
-	var err error
 	switch endpoint.Backend {
 	case BackendOmni:
-		base, err = applyOmniOptionsWithBase(base, options...)
-		if err != nil {
-			return nil, err
-		}
-		return finalizeOmniOptions(base)
+		return applyOmniOptionsWithBase(base, options...)
 	case BackendEmulator:
-		base, err = applyOptionsWithBase(base, options...)
-		if err != nil {
-			return nil, err
-		}
-		return finalizeOptions(base)
+		return applyOptionsWithBase(base, options...)
 	default:
 		return nil, fmt.Errorf("unsupported backend %q", endpoint.Backend)
 	}
@@ -111,9 +93,6 @@ func (a *AttachedRuntime) URI() string {
 func (a *AttachedRuntime) ClientOptions() []option.ClientOption {
 	if a == nil {
 		return nil
-	}
-	if a.opts != nil && len(a.opts.clientOptionsForClient) > 0 {
-		return a.opts.clientOptionsForClient
 	}
 	switch a.backend {
 	case BackendOmni:

--- a/attached.go
+++ b/attached.go
@@ -46,15 +46,34 @@ func NewAttachedRuntimeFromEnv() (*AttachedRuntime, error) {
 	return NewAttachedRuntime(endpoint)
 }
 
+// NewLazyRuntimeFromEnvOrStart returns a [LazyRuntime] that attaches to an
+// external endpoint when one is configured in the environment. When no endpoint
+// env vars are set, it defers container startup until first use. When endpoint
+// env vars are set but [LoadEndpoint] fails, it returns an error instead of
+// falling back to cold start.
+func NewLazyRuntimeFromEnvOrStart(backend Backend, options ...Option) (*LazyRuntime, error) {
+	lr := NewLazyRuntime(backend, options...)
+	if !endpointEnvConfigured() {
+		return lr, nil
+	}
+	endpoint, err := LoadEndpoint()
+	if err != nil {
+		return nil, err
+	}
+	if endpoint.Backend != backend {
+		return nil, fmt.Errorf("spanemuboost: configured endpoint backend %q does not match requested backend %q", endpoint.Backend, backend)
+	}
+	lr.attachedEndpoint = &endpoint
+	return lr, nil
+}
+
 // NewLazyRuntimeOptionalEndpoint returns a [LazyRuntime] that attaches to an
 // external endpoint when one is configured in the environment. Otherwise it
 // starts a container on first use, preserving the existing testcontainers path.
-func NewLazyRuntimeOptionalEndpoint(backend Backend, options ...Option) *LazyRuntime {
-	lr := NewLazyRuntime(backend, options...)
-	if endpoint, err := LoadEndpoint(); err == nil && endpoint.Backend == backend {
-		lr.attachedEndpoint = &endpoint
-	}
-	return lr
+//
+// Deprecated: use [NewLazyRuntimeFromEnvOrStart] to handle endpoint load errors.
+func NewLazyRuntimeOptionalEndpoint(backend Backend, options ...Option) (*LazyRuntime, error) {
+	return NewLazyRuntimeFromEnvOrStart(backend, options...)
 }
 
 func finalizeAttachedOptions(endpoint Endpoint) (*emulatorOptions, error) {

--- a/attached.go
+++ b/attached.go
@@ -1,0 +1,123 @@
+package spanemuboost
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// AttachedRuntime is a [Runtime] connected to an already-running backend.
+// [AttachedRuntime.Close] does not stop the remote process or container.
+type AttachedRuntime struct {
+	backend Backend
+	opts    *emulatorOptions
+	uri     string
+}
+
+func (*AttachedRuntime) spanemuboostRuntime() {}
+
+// NewAttachedRuntime connects to endpoint without starting a container.
+func NewAttachedRuntime(endpoint Endpoint) (*AttachedRuntime, error) {
+	if err := endpoint.validate(); err != nil {
+		return nil, err
+	}
+	opts, err := finalizeAttachedOptions(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return &AttachedRuntime{
+		backend: endpoint.Backend,
+		opts:    opts,
+		uri:     endpoint.URI,
+	}, nil
+}
+
+// NewAttachedRuntimeFromEnv is a convenience wrapper around [LoadEndpoint] and
+// [NewAttachedRuntime].
+func NewAttachedRuntimeFromEnv() (*AttachedRuntime, error) {
+	endpoint, err := LoadEndpoint()
+	if err != nil {
+		return nil, err
+	}
+	return NewAttachedRuntime(endpoint)
+}
+
+// NewLazyRuntimeOptionalEndpoint returns a [LazyRuntime] that attaches to an
+// external endpoint when one is configured in the environment. Otherwise it
+// starts a container on first use, preserving the existing testcontainers path.
+func NewLazyRuntimeOptionalEndpoint(backend Backend, options ...Option) *LazyRuntime {
+	lr := NewLazyRuntime(backend, options...)
+	if endpoint, err := LoadEndpoint(); err == nil && endpoint.Backend == backend {
+		lr.attachedEndpoint = &endpoint
+	}
+	return lr
+}
+
+func finalizeAttachedOptions(endpoint Endpoint) (*emulatorOptions, error) {
+	base := &emulatorOptions{
+		projectID:             endpoint.ProjectID,
+		instanceID:            endpoint.InstanceID,
+		disableCreateInstance: true,
+	}
+	switch endpoint.Backend {
+	case BackendOmni:
+		return finalizeOmniOptions(base)
+	case BackendEmulator:
+		return finalizeOptions(base)
+	default:
+		return nil, fmt.Errorf("unsupported backend %q", endpoint.Backend)
+	}
+}
+
+func (a *AttachedRuntime) URI() string { return a.uri }
+
+func (a *AttachedRuntime) ClientOptions() []option.ClientOption {
+	if a.opts != nil && len(a.opts.clientOptionsForClient) > 0 {
+		return a.opts.clientOptionsForClient
+	}
+	switch a.backend {
+	case BackendOmni:
+		return []option.ClientOption{
+			option.WithEndpoint(a.uri),
+			option.WithoutAuthentication(),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		}
+	default:
+		return []option.ClientOption{
+			option.WithEndpoint("passthrough:///" + a.uri),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+			option.WithoutAuthentication(),
+			internaloption.SkipDialSettingsValidation(),
+		}
+	}
+}
+
+// Close is a no-op for attached runtimes because this handle does not own the
+// remote backend lifecycle.
+func (a *AttachedRuntime) Close() error { return nil }
+
+func (a *AttachedRuntime) ProjectID() string  { return a.opts.projectID }
+func (a *AttachedRuntime) InstanceID() string { return a.opts.instanceID }
+func (a *AttachedRuntime) DatabaseID() string { return a.opts.databaseID }
+
+func (a *AttachedRuntime) ProjectPath() string  { return a.opts.ProjectPath() }
+func (a *AttachedRuntime) InstancePath() string { return a.opts.InstancePath() }
+func (a *AttachedRuntime) DatabasePath() string { return a.opts.DatabasePath() }
+
+func (a *AttachedRuntime) inheritedOptions(options ...Option) (*emulatorOptions, error) {
+	base := inheritedRuntimeOptions(a.opts)
+	switch a.backend {
+	case BackendOmni:
+		return applyOmniOptionsWithBase(base, options...)
+	default:
+		return applyOptionsWithBase(base, options...)
+	}
+}
+
+func (a *AttachedRuntime) runtimePlatform(context.Context) (string, error) {
+	return "attached", nil
+}

--- a/attached.go
+++ b/attached.go
@@ -92,9 +92,17 @@ func finalizeAttachedOptions(endpoint Endpoint) (*emulatorOptions, error) {
 	}
 }
 
-func (a *AttachedRuntime) URI() string { return a.uri }
+func (a *AttachedRuntime) URI() string {
+	if a == nil {
+		return ""
+	}
+	return a.uri
+}
 
 func (a *AttachedRuntime) ClientOptions() []option.ClientOption {
+	if a == nil {
+		return nil
+	}
 	if a.opts != nil && len(a.opts.clientOptionsForClient) > 0 {
 		return a.opts.clientOptionsForClient
 	}
@@ -119,15 +127,48 @@ func (a *AttachedRuntime) ClientOptions() []option.ClientOption {
 // remote backend lifecycle.
 func (a *AttachedRuntime) Close() error { return nil }
 
-func (a *AttachedRuntime) ProjectID() string  { return a.opts.projectID }
-func (a *AttachedRuntime) InstanceID() string { return a.opts.instanceID }
-func (a *AttachedRuntime) DatabaseID() string { return a.opts.databaseID }
+func (a *AttachedRuntime) ProjectID() string {
+	if a == nil || a.opts == nil {
+		return ""
+	}
+	return a.opts.projectID
+}
+func (a *AttachedRuntime) InstanceID() string {
+	if a == nil || a.opts == nil {
+		return ""
+	}
+	return a.opts.instanceID
+}
+func (a *AttachedRuntime) DatabaseID() string {
+	if a == nil || a.opts == nil {
+		return ""
+	}
+	return a.opts.databaseID
+}
 
-func (a *AttachedRuntime) ProjectPath() string  { return a.opts.ProjectPath() }
-func (a *AttachedRuntime) InstancePath() string { return a.opts.InstancePath() }
-func (a *AttachedRuntime) DatabasePath() string { return a.opts.DatabasePath() }
+func (a *AttachedRuntime) ProjectPath() string {
+	if a == nil || a.opts == nil {
+		return ""
+	}
+	return a.opts.ProjectPath()
+}
+func (a *AttachedRuntime) InstancePath() string {
+	if a == nil || a.opts == nil {
+		return ""
+	}
+	return a.opts.InstancePath()
+}
+func (a *AttachedRuntime) DatabasePath() string {
+	if a == nil || a.opts == nil {
+		return ""
+	}
+	return a.opts.DatabasePath()
+}
 
 func (a *AttachedRuntime) inheritedOptions(options ...Option) (*emulatorOptions, error) {
+	if a == nil || a.opts == nil {
+		return nil, fmt.Errorf("spanemuboost: attached runtime or options is nil")
+	}
 	base := inheritedRuntimeOptions(a.opts)
 	switch a.backend {
 	case BackendOmni:

--- a/cmd/spanemuboost/main.go
+++ b/cmd/spanemuboost/main.go
@@ -21,6 +21,11 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
+	case "stop":
+		if err := runStop(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 	default:
 		usage()
 		os.Exit(2)
@@ -40,15 +45,28 @@ func runServe(args []string) error {
 	return spanemuboost.ServeFromConfig(ctx, cfg)
 }
 
+func runStop(args []string) error {
+	cfg, err := spanemuboost.ParseStopArgs(args)
+	if err != nil {
+		return err
+	}
+	return spanemuboost.StopFromConfig(context.Background(), cfg)
+}
+
 func usage() {
 	fmt.Fprintf(os.Stderr, `spanemuboost manages long-lived Spanner test backends.
 
 Usage:
-  spanemuboost serve <emulator|omni> --endpoint-file path
+  spanemuboost serve <emulator|omni> --endpoint-file path [--pid-file path]
+  spanemuboost stop --endpoint-file path [--pid-file path]
 
 Examples:
   spanemuboost serve omni --endpoint-file /tmp/omni-endpoint.json
+  spanemuboost stop --endpoint-file /tmp/omni-endpoint.json
   SPANEMUBOOST_ENDPOINT_FILE=/tmp/omni-endpoint.json go test ./...
+
+The endpoint file is owned by serve: it is written on startup and removed on
+exit. Unset SPANEMUBOOST_ENDPOINT_FILE after stopping the lifecycle manager.
 
 `)
 }

--- a/cmd/spanemuboost/main.go
+++ b/cmd/spanemuboost/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/apstndb/spanemuboost"
 )
@@ -30,14 +32,19 @@ func runServe(args []string) error {
 	if err != nil {
 		return err
 	}
-	return spanemuboost.ServeFromConfig(context.Background(), cfg)
+	if cfg.EndpointFile == "" {
+		return fmt.Errorf("--endpoint-file is required")
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return spanemuboost.ServeFromConfig(ctx, cfg)
 }
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `spanemuboost manages long-lived Spanner test backends.
 
 Usage:
-  spanemuboost serve <emulator|omni> [--endpoint-file path]
+  spanemuboost serve <emulator|omni> --endpoint-file path
 
 Examples:
   spanemuboost serve omni --endpoint-file /tmp/omni-endpoint.json

--- a/cmd/spanemuboost/main.go
+++ b/cmd/spanemuboost/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/apstndb/spanemuboost"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "serve":
+		if err := runServe(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	default:
+		usage()
+		os.Exit(2)
+	}
+}
+
+func runServe(args []string) error {
+	cfg, err := spanemuboost.ParseServeArgs(args)
+	if err != nil {
+		return err
+	}
+	return spanemuboost.ServeFromConfig(context.Background(), cfg)
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `spanemuboost manages long-lived Spanner test backends.
+
+Usage:
+  spanemuboost serve <emulator|omni> [--endpoint-file path]
+
+Examples:
+  spanemuboost serve omni --endpoint-file /tmp/omni-endpoint.json
+  SPANEMUBOOST_ENDPOINT_FILE=/tmp/omni-endpoint.json go test ./...
+
+`)
+}

--- a/endpoint.go
+++ b/endpoint.go
@@ -1,0 +1,144 @@
+package spanemuboost
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	endpointFileEnv     = "SPANEMUBOOST_ENDPOINT_FILE"
+	omniURIEnv          = "SPANEMUBOOST_OMNI_URI"
+	omniProjectIDEnv    = "SPANEMUBOOST_OMNI_PROJECT_ID"
+	omniInstanceIDEnv   = "SPANEMUBOOST_OMNI_INSTANCE_ID"
+	emulatorURIEnv      = "SPANEMUBOOST_EMULATOR_URI"
+	emulatorProjectEnv  = "SPANEMUBOOST_EMULATOR_PROJECT_ID"
+	emulatorInstanceEnv = "SPANEMUBOOST_EMULATOR_INSTANCE_ID"
+)
+
+// Endpoint describes a running spanemuboost-compatible Spanner backend that
+// clients can attach to without starting a new container.
+type Endpoint struct {
+	Backend    Backend `json:"backend"`
+	URI        string  `json:"uri"`
+	ProjectID  string  `json:"project_id"`
+	InstanceID string  `json:"instance_id"`
+}
+
+// EndpointFromRuntime builds an [Endpoint] from a started [Runtime].
+func EndpointFromRuntime(runtime Runtime) (Endpoint, error) {
+	if runtime == nil || isNilRuntimeValue(runtime) {
+		return Endpoint{}, errors.New("spanemuboost: runtime is nil")
+	}
+	uri := strings.TrimSpace(runtime.URI())
+	if uri == "" {
+		return Endpoint{}, errors.New("spanemuboost: runtime URI is empty")
+	}
+	backend := backendForRuntime(runtime)
+	return Endpoint{
+		Backend:    backend,
+		URI:        uri,
+		ProjectID:  runtime.ProjectID(),
+		InstanceID: runtime.InstanceID(),
+	}, nil
+}
+
+func backendForRuntime(runtime Runtime) Backend {
+	switch runtime.(type) {
+	case *omniRuntime:
+		return BackendOmni
+	default:
+		return BackendEmulator
+	}
+}
+
+// EndpointConfigured reports whether [LoadEndpoint] is expected to succeed from
+// the current process environment.
+func EndpointConfigured() bool {
+	_, err := LoadEndpoint()
+	return err == nil
+}
+
+// LoadEndpoint reads connection metadata from SPANEMUBOOST_ENDPOINT_FILE or
+// backend-specific URI env vars.
+//
+// When SPANEMUBOOST_ENDPOINT_FILE is set, the JSON file takes precedence.
+// Otherwise Omni is selected when SPANEMUBOOST_OMNI_URI is set, and the emulator
+// path is selected when SPANEMUBOOST_EMULATOR_URI is set.
+func LoadEndpoint() (Endpoint, error) {
+	if path := strings.TrimSpace(os.Getenv(endpointFileEnv)); path != "" {
+		return ReadEndpointFile(path)
+	}
+	if uri := strings.TrimSpace(os.Getenv(omniURIEnv)); uri != "" {
+		return Endpoint{
+			Backend:    BackendOmni,
+			URI:        uri,
+			ProjectID:  cmpOrEnv(omniProjectIDEnv, defaultOmniProjectID),
+			InstanceID: cmpOrEnv(omniInstanceIDEnv, defaultOmniInstanceID),
+		}, nil
+	}
+	if uri := strings.TrimSpace(os.Getenv(emulatorURIEnv)); uri != "" {
+		return Endpoint{
+			Backend:    BackendEmulator,
+			URI:        uri,
+			ProjectID:  cmpOrEnv(emulatorProjectEnv, DefaultProjectID),
+			InstanceID: cmpOrEnv(emulatorInstanceEnv, DefaultInstanceID),
+		}, nil
+	}
+	return Endpoint{}, fmt.Errorf("spanemuboost: no external endpoint configured; set %s or %s", endpointFileEnv, omniURIEnv)
+}
+
+func cmpOrEnv(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+// ReadEndpointFile loads an [Endpoint] from a JSON file written by [SaveEndpoint]
+// or `spanemuboost serve`.
+func ReadEndpointFile(path string) (Endpoint, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Endpoint{}, fmt.Errorf("spanemuboost: read endpoint file %q: %w", path, err)
+	}
+	var endpoint Endpoint
+	if err := json.Unmarshal(data, &endpoint); err != nil {
+		return Endpoint{}, fmt.Errorf("spanemuboost: parse endpoint file %q: %w", path, err)
+	}
+	return endpoint, endpoint.validate()
+}
+
+// SaveEndpoint writes endpoint metadata as JSON with mode 0600.
+func SaveEndpoint(path string, endpoint Endpoint) error {
+	if err := endpoint.validate(); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(endpoint, "", "  ")
+	if err != nil {
+		return fmt.Errorf("spanemuboost: marshal endpoint: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("spanemuboost: write endpoint file %q: %w", path, err)
+	}
+	return nil
+}
+
+func (e Endpoint) validate() error {
+	if e.Backend != BackendEmulator && e.Backend != BackendOmni {
+		return fmt.Errorf("spanemuboost: endpoint backend %q is unsupported", e.Backend)
+	}
+	if strings.TrimSpace(e.URI) == "" {
+		return errors.New("spanemuboost: endpoint URI is required")
+	}
+	if strings.TrimSpace(e.ProjectID) == "" {
+		return errors.New("spanemuboost: endpoint project_id is required")
+	}
+	if strings.TrimSpace(e.InstanceID) == "" {
+		return errors.New("spanemuboost: endpoint instance_id is required")
+	}
+	return nil
+}

--- a/endpoint.go
+++ b/endpoint.go
@@ -141,6 +141,9 @@ func SaveEndpoint(path string, endpoint Endpoint) error {
 	}
 	data = append(data, '\n')
 	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("spanemuboost: create endpoint directory %q: %w", dir, err)
+	}
 	tmp, err := os.CreateTemp(dir, ".endpoint-*.json")
 	if err != nil {
 		return fmt.Errorf("spanemuboost: create temp endpoint file in %q: %w", dir, err)

--- a/endpoint.go
+++ b/endpoint.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -46,19 +47,33 @@ func EndpointFromRuntime(runtime Runtime) (Endpoint, error) {
 }
 
 func backendForRuntime(runtime Runtime) Backend {
-	switch runtime.(type) {
+	switch r := runtime.(type) {
 	case *omniRuntime:
 		return BackendOmni
+	case *AttachedRuntime:
+		return r.backend
 	default:
 		return BackendEmulator
 	}
 }
 
-// EndpointConfigured reports whether [LoadEndpoint] is expected to succeed from
-// the current process environment.
+// EndpointConfigured reports whether external endpoint env vars are set in the
+// current process environment. It does not validate that [LoadEndpoint] succeeds.
 func EndpointConfigured() bool {
-	_, err := LoadEndpoint()
-	return err == nil
+	return endpointEnvConfigured()
+}
+
+func endpointEnvConfigured() bool {
+	if strings.TrimSpace(os.Getenv(endpointFileEnv)) != "" {
+		return true
+	}
+	if strings.TrimSpace(os.Getenv(omniURIEnv)) != "" {
+		return true
+	}
+	if strings.TrimSpace(os.Getenv(emulatorURIEnv)) != "" {
+		return true
+	}
+	return false
 }
 
 // LoadEndpoint reads connection metadata from SPANEMUBOOST_ENDPOINT_FILE or
@@ -121,9 +136,33 @@ func SaveEndpoint(path string, endpoint Endpoint) error {
 		return fmt.Errorf("spanemuboost: marshal endpoint: %w", err)
 	}
 	data = append(data, '\n')
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".endpoint-*.json")
+	if err != nil {
+		return fmt.Errorf("spanemuboost: create temp endpoint file in %q: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("spanemuboost: write temp endpoint file %q: %w", tmpPath, err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("spanemuboost: chmod temp endpoint file %q: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("spanemuboost: close temp endpoint file %q: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("spanemuboost: write endpoint file %q: %w", path, err)
 	}
+	cleanup = false
 	return nil
 }
 

--- a/endpoint.go
+++ b/endpoint.go
@@ -26,6 +26,11 @@ type Endpoint struct {
 	URI        string  `json:"uri"`
 	ProjectID  string  `json:"project_id"`
 	InstanceID string  `json:"instance_id"`
+
+	// Lifecycle metadata is populated by spanemuboost serve and used by stop.
+	ManagedBy string `json:"managed_by,omitempty"`
+	PID       int    `json:"pid,omitempty"`
+	StartedAt string `json:"started_at,omitempty"`
 }
 
 // EndpointFromRuntime builds an [Endpoint] from a started [Runtime].
@@ -67,6 +72,23 @@ func EndpointConfigured() bool {
 	return endpointEnvConfigured()
 }
 
+// EndpointConfiguredForBackend reports whether an endpoint for the requested
+// backend is configured. Unlike [EndpointConfigured], this ignores unrelated
+// backend URI env vars so callers can distinguish Omni from emulator endpoints.
+func EndpointConfiguredForBackend(backend Backend) bool {
+	if strings.TrimSpace(os.Getenv(endpointFileEnv)) != "" {
+		return true
+	}
+	switch backend {
+	case BackendOmni:
+		return strings.TrimSpace(os.Getenv(omniURIEnv)) != ""
+	case BackendEmulator:
+		return strings.TrimSpace(os.Getenv(emulatorURIEnv)) != ""
+	default:
+		return false
+	}
+}
+
 func endpointEnvConfigured() bool {
 	if strings.TrimSpace(os.Getenv(endpointFileEnv)) != "" {
 		return true
@@ -91,22 +113,65 @@ func LoadEndpoint() (Endpoint, error) {
 		return ReadEndpointFile(path)
 	}
 	if uri := strings.TrimSpace(os.Getenv(omniURIEnv)); uri != "" {
-		return Endpoint{
+		endpoint := Endpoint{
 			Backend:    BackendOmni,
 			URI:        uri,
 			ProjectID:  cmpOrEnv(omniProjectIDEnv, defaultOmniProjectID),
 			InstanceID: cmpOrEnv(omniInstanceIDEnv, defaultOmniInstanceID),
-		}, nil
+		}
+		return endpoint, endpoint.validate()
 	}
 	if uri := strings.TrimSpace(os.Getenv(emulatorURIEnv)); uri != "" {
-		return Endpoint{
+		endpoint := Endpoint{
 			Backend:    BackendEmulator,
 			URI:        uri,
 			ProjectID:  cmpOrEnv(emulatorProjectEnv, DefaultProjectID),
 			InstanceID: cmpOrEnv(emulatorInstanceEnv, DefaultInstanceID),
-		}, nil
+		}
+		return endpoint, endpoint.validate()
 	}
 	return Endpoint{}, fmt.Errorf("spanemuboost: no external endpoint configured; set %s, %s, or %s", endpointFileEnv, omniURIEnv, emulatorURIEnv)
+}
+
+// LoadEndpointForBackend reads endpoint metadata for the requested backend.
+// When SPANEMUBOOST_ENDPOINT_FILE is set, the file backend must match.
+// Otherwise only the URI env var for the requested backend is considered.
+func LoadEndpointForBackend(backend Backend) (Endpoint, error) {
+	if path := strings.TrimSpace(os.Getenv(endpointFileEnv)); path != "" {
+		endpoint, err := ReadEndpointFile(path)
+		if err != nil {
+			return Endpoint{}, err
+		}
+		if endpoint.Backend != backend {
+			return Endpoint{}, fmt.Errorf("spanemuboost: configured endpoint backend %q does not match requested backend %q", endpoint.Backend, backend)
+		}
+		return endpoint, nil
+	}
+	switch backend {
+	case BackendOmni:
+		if uri := strings.TrimSpace(os.Getenv(omniURIEnv)); uri != "" {
+			endpoint := Endpoint{
+				Backend:    BackendOmni,
+				URI:        uri,
+				ProjectID:  cmpOrEnv(omniProjectIDEnv, defaultOmniProjectID),
+				InstanceID: cmpOrEnv(omniInstanceIDEnv, defaultOmniInstanceID),
+			}
+			return endpoint, endpoint.validate()
+		}
+	case BackendEmulator:
+		if uri := strings.TrimSpace(os.Getenv(emulatorURIEnv)); uri != "" {
+			endpoint := Endpoint{
+				Backend:    BackendEmulator,
+				URI:        uri,
+				ProjectID:  cmpOrEnv(emulatorProjectEnv, DefaultProjectID),
+				InstanceID: cmpOrEnv(emulatorInstanceEnv, DefaultInstanceID),
+			}
+			return endpoint, endpoint.validate()
+		}
+	default:
+		return Endpoint{}, fmt.Errorf("spanemuboost: unsupported backend %q", backend)
+	}
+	return Endpoint{}, fmt.Errorf("spanemuboost: no external endpoint configured for backend %q", backend)
 }
 
 func cmpOrEnv(key, fallback string) string {

--- a/endpoint.go
+++ b/endpoint.go
@@ -38,12 +38,16 @@ func EndpointFromRuntime(runtime Runtime) (Endpoint, error) {
 		return Endpoint{}, errors.New("spanemuboost: runtime URI is empty")
 	}
 	backend := backendForRuntime(runtime)
-	return Endpoint{
+	endpoint := Endpoint{
 		Backend:    backend,
 		URI:        uri,
 		ProjectID:  runtime.ProjectID(),
 		InstanceID: runtime.InstanceID(),
-	}, nil
+	}
+	if err := endpoint.validate(); err != nil {
+		return Endpoint{}, err
+	}
+	return endpoint, nil
 }
 
 func backendForRuntime(runtime Runtime) Backend {

--- a/endpoint.go
+++ b/endpoint.go
@@ -102,7 +102,7 @@ func LoadEndpoint() (Endpoint, error) {
 			InstanceID: cmpOrEnv(emulatorInstanceEnv, DefaultInstanceID),
 		}, nil
 	}
-	return Endpoint{}, fmt.Errorf("spanemuboost: no external endpoint configured; set %s or %s", endpointFileEnv, omniURIEnv)
+	return Endpoint{}, fmt.Errorf("spanemuboost: no external endpoint configured; set %s, %s, or %s", endpointFileEnv, omniURIEnv, emulatorURIEnv)
 }
 
 func cmpOrEnv(key, fallback string) string {

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -1,6 +1,7 @@
 package spanemuboost
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -93,6 +94,39 @@ func TestParseServeArgs(t *testing.T) {
 	}
 	if cfg.Backend != BackendOmni || cfg.EndpointFile != "/tmp/omni.json" {
 		t.Fatalf("ParseServeArgs() = %#v, want omni + /tmp/omni.json", cfg)
+	}
+}
+
+func TestLoadEndpointMissingEnvMentionsEmulatorURI(t *testing.T) {
+	t.Setenv(endpointFileEnv, "")
+	t.Setenv(omniURIEnv, "")
+	t.Setenv(emulatorURIEnv, "")
+
+	_, err := LoadEndpoint()
+	if err == nil {
+		t.Fatal("LoadEndpoint() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), emulatorURIEnv) {
+		t.Fatalf("LoadEndpoint() error = %v, want mention of %s", err, emulatorURIEnv)
+	}
+}
+
+func TestRuntimePlatformAttached(t *testing.T) {
+	runtime, err := NewAttachedRuntime(Endpoint{
+		Backend:    BackendOmni,
+		URI:        "127.0.0.1:15000",
+		ProjectID:  defaultOmniProjectID,
+		InstanceID: defaultOmniInstanceID,
+	})
+	if err != nil {
+		t.Fatalf("NewAttachedRuntime() error = %v", err)
+	}
+	got, err := RuntimePlatform(context.Background(), runtime)
+	if err != nil {
+		t.Fatalf("RuntimePlatform() error = %v", err)
+	}
+	if got != "attached" {
+		t.Fatalf("RuntimePlatform() = %q, want attached", got)
 	}
 }
 

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -203,6 +203,42 @@ func TestNewLazyRuntimeFromEnvOrStartRejectsBackendMismatch(t *testing.T) {
 	}
 }
 
+func TestNewAttachedRuntimeAppliesOptions(t *testing.T) {
+	runtime, err := NewAttachedRuntime(Endpoint{
+		Backend:    BackendOmni,
+		URI:        "127.0.0.1:15000",
+		ProjectID:  defaultOmniProjectID,
+		InstanceID: defaultOmniInstanceID,
+	}, WithDatabaseID("attached-db"))
+	if err != nil {
+		t.Fatalf("NewAttachedRuntime() error = %v", err)
+	}
+	if got := runtime.DatabaseID(); got != "attached-db" {
+		t.Fatalf("DatabaseID() = %q, want attached-db", got)
+	}
+}
+
+func TestSaveEndpointCreatesParentDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+	path := filepath.Join(dir, "endpoint.json")
+	endpoint := Endpoint{
+		Backend:    BackendOmni,
+		URI:        "127.0.0.1:15000",
+		ProjectID:  defaultOmniProjectID,
+		InstanceID: defaultOmniInstanceID,
+	}
+	if err := SaveEndpoint(path, endpoint); err != nil {
+		t.Fatalf("SaveEndpoint() error = %v", err)
+	}
+	got, err := ReadEndpointFile(path)
+	if err != nil {
+		t.Fatalf("ReadEndpointFile() error = %v", err)
+	}
+	if got != endpoint {
+		t.Fatalf("ReadEndpointFile() = %#v, want %#v", got, endpoint)
+	}
+}
+
 func TestEndpointFromRuntimeRejectsInvalidEndpoint(t *testing.T) {
 	runtime := &invalidEndpointRuntime{}
 	_, err := EndpointFromRuntime(runtime)

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -56,12 +56,21 @@ func TestLoadEndpointFromOmniEnv(t *testing.T) {
 func TestEndpointConfigured(t *testing.T) {
 	t.Setenv(endpointFileEnv, "")
 	t.Setenv(omniURIEnv, "")
+	t.Setenv(emulatorURIEnv, "")
 	if EndpointConfigured() {
 		t.Fatal("EndpointConfigured() = true, want false")
 	}
 	t.Setenv(omniURIEnv, "127.0.0.1:15000")
 	if !EndpointConfigured() {
 		t.Fatal("EndpointConfigured() = false, want true")
+	}
+}
+
+func TestEndpointConfiguredWithBrokenFile(t *testing.T) {
+	t.Setenv(endpointFileEnv, filepath.Join(t.TempDir(), "missing.json"))
+	t.Setenv(omniURIEnv, "")
+	if !EndpointConfigured() {
+		t.Fatal("EndpointConfigured() = false, want true when endpoint file env is set")
 	}
 }
 
@@ -109,12 +118,77 @@ func TestNewLazyRuntimeOptionalEndpointUsesEnv(t *testing.T) {
 	t.Setenv(endpointFileEnv, "")
 	t.Setenv(omniURIEnv, "127.0.0.1:15000")
 
-	lazy := NewLazyRuntimeOptionalEndpoint(BackendOmni)
+	lazy, err := NewLazyRuntimeOptionalEndpoint(BackendOmni)
+	if err != nil {
+		t.Fatalf("NewLazyRuntimeOptionalEndpoint() error = %v", err)
+	}
 	if lazy.attachedEndpoint == nil {
 		t.Fatal("attachedEndpoint = nil, want non-nil")
 	}
 	if lazy.attachedEndpoint.URI != "127.0.0.1:15000" {
 		t.Fatalf("attachedEndpoint.URI = %q, want 127.0.0.1:15000", lazy.attachedEndpoint.URI)
+	}
+}
+
+func TestNewLazyRuntimeFromEnvOrStartColdStartWithoutEnv(t *testing.T) {
+	t.Setenv(endpointFileEnv, "")
+	t.Setenv(omniURIEnv, "")
+	t.Setenv(emulatorURIEnv, "")
+
+	lazy, err := NewLazyRuntimeFromEnvOrStart(BackendOmni)
+	if err != nil {
+		t.Fatalf("NewLazyRuntimeFromEnvOrStart() error = %v, want nil", err)
+	}
+	if lazy.attachedEndpoint != nil {
+		t.Fatal("attachedEndpoint = non-nil, want nil")
+	}
+}
+
+func TestNewLazyRuntimeFromEnvOrStartErrorsOnBrokenEndpointFile(t *testing.T) {
+	t.Setenv(endpointFileEnv, filepath.Join(t.TempDir(), "missing.json"))
+	t.Setenv(omniURIEnv, "")
+
+	lazy, err := NewLazyRuntimeFromEnvOrStart(BackendOmni)
+	if err == nil {
+		t.Fatal("NewLazyRuntimeFromEnvOrStart() error = nil, want non-nil")
+	}
+	if lazy != nil {
+		t.Fatal("NewLazyRuntimeFromEnvOrStart() runtime = non-nil, want nil")
+	}
+}
+
+func TestNewLazyRuntimeFromEnvOrStartRejectsBackendMismatch(t *testing.T) {
+	t.Setenv(endpointFileEnv, "")
+	t.Setenv(omniURIEnv, "127.0.0.1:15000")
+
+	_, err := NewLazyRuntimeFromEnvOrStart(BackendEmulator)
+	if err == nil {
+		t.Fatal("NewLazyRuntimeFromEnvOrStart() error = nil, want non-nil")
+	}
+}
+
+func TestEndpointFromRuntimeAttached(t *testing.T) {
+	runtime, err := NewAttachedRuntime(Endpoint{
+		Backend:    BackendOmni,
+		URI:        "127.0.0.1:15000",
+		ProjectID:  defaultOmniProjectID,
+		InstanceID: defaultOmniInstanceID,
+	})
+	if err != nil {
+		t.Fatalf("NewAttachedRuntime() error = %v", err)
+	}
+	got, err := EndpointFromRuntime(runtime)
+	if err != nil {
+		t.Fatalf("EndpointFromRuntime() error = %v", err)
+	}
+	want := Endpoint{
+		Backend:    BackendOmni,
+		URI:        "127.0.0.1:15000",
+		ProjectID:  defaultOmniProjectID,
+		InstanceID: defaultOmniInstanceID,
+	}
+	if got != want {
+		t.Fatalf("EndpointFromRuntime() = %#v, want %#v", got, want)
 	}
 }
 

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -150,13 +150,13 @@ func TestNewAttachedRuntimeCloseIsNoOp(t *testing.T) {
 	}
 }
 
-func TestNewLazyRuntimeOptionalEndpointUsesEnv(t *testing.T) {
+func TestNewLazyRuntimeFromEnvOrStartUsesEnv(t *testing.T) {
 	t.Setenv(endpointFileEnv, "")
 	t.Setenv(omniURIEnv, "127.0.0.1:15000")
 
-	lazy, err := NewLazyRuntimeOptionalEndpoint(BackendOmni)
+	lazy, err := NewLazyRuntimeFromEnvOrStart(BackendOmni)
 	if err != nil {
-		t.Fatalf("NewLazyRuntimeOptionalEndpoint() error = %v", err)
+		t.Fatalf("NewLazyRuntimeFromEnvOrStart() error = %v", err)
 	}
 	if lazy.attachedEndpoint == nil {
 		t.Fatal("attachedEndpoint = nil, want non-nil")
@@ -200,6 +200,56 @@ func TestNewLazyRuntimeFromEnvOrStartRejectsBackendMismatch(t *testing.T) {
 	_, err := NewLazyRuntimeFromEnvOrStart(BackendEmulator)
 	if err == nil {
 		t.Fatal("NewLazyRuntimeFromEnvOrStart() error = nil, want non-nil")
+	}
+}
+
+func TestNewAttachedRuntimeWithRandomDatabaseID(t *testing.T) {
+	runtime, err := NewAttachedRuntime(Endpoint{
+		Backend:    BackendOmni,
+		URI:        "127.0.0.1:15000",
+		ProjectID:  defaultOmniProjectID,
+		InstanceID: defaultOmniInstanceID,
+	}, WithRandomDatabaseID())
+	if err != nil {
+		t.Fatalf("NewAttachedRuntime() error = %v", err)
+	}
+	if runtime.DatabaseID() == "" || runtime.DatabaseID() == DefaultDatabaseID {
+		t.Fatalf("DatabaseID() = %q, want generated random ID", runtime.DatabaseID())
+	}
+}
+
+func TestNewLazyRuntimeFromEnvOrStartAttachPathWithRandomDatabaseID(t *testing.T) {
+	t.Setenv(endpointFileEnv, "")
+	t.Setenv(omniURIEnv, "127.0.0.1:15000")
+
+	lazy, err := NewLazyRuntimeFromEnvOrStart(BackendOmni, WithRandomDatabaseID())
+	if err != nil {
+		t.Fatalf("NewLazyRuntimeFromEnvOrStart() error = %v", err)
+	}
+	if lazy.attachedEndpoint == nil {
+		t.Fatal("attachedEndpoint = nil, want non-nil")
+	}
+	runtime, err := NewAttachedRuntime(*lazy.attachedEndpoint, lazy.opts...)
+	if err != nil {
+		t.Fatalf("NewAttachedRuntime() via lazy attach path error = %v", err)
+	}
+	if runtime.DatabaseID() == "" || runtime.DatabaseID() == DefaultDatabaseID {
+		t.Fatalf("DatabaseID() = %q, want generated random ID", runtime.DatabaseID())
+	}
+}
+
+func TestAttachedRuntimeClientOptionsReturnsTransportOptions(t *testing.T) {
+	runtime, err := NewAttachedRuntime(Endpoint{
+		Backend:    BackendOmni,
+		URI:        "127.0.0.1:15000",
+		ProjectID:  defaultOmniProjectID,
+		InstanceID: defaultOmniInstanceID,
+	}, WithClientOptionsForClient(option.WithQuotaProject("client-only")))
+	if err != nil {
+		t.Fatalf("NewAttachedRuntime() error = %v", err)
+	}
+	if got := len(runtime.ClientOptions()); got != 3 {
+		t.Fatalf("ClientOptions() returned %d options, want 3 transport options", got)
 	}
 }
 

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -1,0 +1,129 @@
+package spanemuboost
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadEndpointFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "endpoint.json")
+	endpoint := Endpoint{
+		Backend:    BackendOmni,
+		URI:        "127.0.0.1:15000",
+		ProjectID:  defaultOmniProjectID,
+		InstanceID: defaultOmniInstanceID,
+	}
+	if err := SaveEndpoint(path, endpoint); err != nil {
+		t.Fatalf("SaveEndpoint() error = %v", err)
+	}
+
+	t.Setenv(endpointFileEnv, path)
+	t.Setenv(omniURIEnv, "")
+
+	got, err := LoadEndpoint()
+	if err != nil {
+		t.Fatalf("LoadEndpoint() error = %v", err)
+	}
+	if got != endpoint {
+		t.Fatalf("LoadEndpoint() = %#v, want %#v", got, endpoint)
+	}
+}
+
+func TestLoadEndpointFromOmniEnv(t *testing.T) {
+	t.Setenv(endpointFileEnv, "")
+	t.Setenv(omniURIEnv, "127.0.0.1:15000")
+	t.Setenv(omniProjectIDEnv, "proj")
+	t.Setenv(omniInstanceIDEnv, "inst")
+
+	got, err := LoadEndpoint()
+	if err != nil {
+		t.Fatalf("LoadEndpoint() error = %v", err)
+	}
+	want := Endpoint{
+		Backend:    BackendOmni,
+		URI:        "127.0.0.1:15000",
+		ProjectID:  "proj",
+		InstanceID: "inst",
+	}
+	if got != want {
+		t.Fatalf("LoadEndpoint() = %#v, want %#v", got, want)
+	}
+}
+
+func TestEndpointConfigured(t *testing.T) {
+	t.Setenv(endpointFileEnv, "")
+	t.Setenv(omniURIEnv, "")
+	if EndpointConfigured() {
+		t.Fatal("EndpointConfigured() = true, want false")
+	}
+	t.Setenv(omniURIEnv, "127.0.0.1:15000")
+	if !EndpointConfigured() {
+		t.Fatal("EndpointConfigured() = false, want true")
+	}
+}
+
+func TestSaveEndpointRejectsInvalidBackend(t *testing.T) {
+	err := SaveEndpoint(filepath.Join(t.TempDir(), "endpoint.json"), Endpoint{
+		Backend:    Backend("bad"),
+		URI:        "127.0.0.1:1",
+		ProjectID:  "p",
+		InstanceID: "i",
+	})
+	if err == nil {
+		t.Fatal("SaveEndpoint() error = nil, want non-nil")
+	}
+}
+
+func TestParseServeArgs(t *testing.T) {
+	cfg, err := ParseServeArgs([]string{"omni", "--endpoint-file", "/tmp/omni.json"})
+	if err != nil {
+		t.Fatalf("ParseServeArgs() error = %v", err)
+	}
+	if cfg.Backend != BackendOmni || cfg.EndpointFile != "/tmp/omni.json" {
+		t.Fatalf("ParseServeArgs() = %#v, want omni + /tmp/omni.json", cfg)
+	}
+}
+
+func TestNewAttachedRuntimeCloseIsNoOp(t *testing.T) {
+	runtime, err := NewAttachedRuntime(Endpoint{
+		Backend:    BackendOmni,
+		URI:        "127.0.0.1:15000",
+		ProjectID:  defaultOmniProjectID,
+		InstanceID: defaultOmniInstanceID,
+	})
+	if err != nil {
+		t.Fatalf("NewAttachedRuntime() error = %v", err)
+	}
+	if err := runtime.Close(); err != nil {
+		t.Fatalf("Close() error = %v, want nil", err)
+	}
+	if err := runtime.Close(); err != nil {
+		t.Fatalf("second Close() error = %v, want nil", err)
+	}
+}
+
+func TestNewLazyRuntimeOptionalEndpointUsesEnv(t *testing.T) {
+	t.Setenv(endpointFileEnv, "")
+	t.Setenv(omniURIEnv, "127.0.0.1:15000")
+
+	lazy := NewLazyRuntimeOptionalEndpoint(BackendOmni)
+	if lazy.attachedEndpoint == nil {
+		t.Fatal("attachedEndpoint = nil, want non-nil")
+	}
+	if lazy.attachedEndpoint.URI != "127.0.0.1:15000" {
+		t.Fatalf("attachedEndpoint.URI = %q, want 127.0.0.1:15000", lazy.attachedEndpoint.URI)
+	}
+}
+
+func TestReadEndpointFileMissing(t *testing.T) {
+	_, err := ReadEndpointFile(filepath.Join(t.TempDir(), "missing.json"))
+	if err == nil {
+		t.Fatal("ReadEndpointFile() error = nil, want non-nil")
+	}
+	if !os.IsNotExist(err) && !strings.Contains(err.Error(), "read endpoint file") {
+		t.Fatalf("ReadEndpointFile() error = %v", err)
+	}
+}

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -194,12 +194,111 @@ func TestNewLazyRuntimeFromEnvOrStartErrorsOnBrokenEndpointFile(t *testing.T) {
 }
 
 func TestNewLazyRuntimeFromEnvOrStartRejectsBackendMismatch(t *testing.T) {
-	t.Setenv(endpointFileEnv, "")
-	t.Setenv(omniURIEnv, "127.0.0.1:15000")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "endpoint.json")
+	endpoint := Endpoint{
+		Backend:    BackendOmni,
+		URI:        "127.0.0.1:15000",
+		ProjectID:  defaultOmniProjectID,
+		InstanceID: defaultOmniInstanceID,
+	}
+	if err := SaveEndpoint(path, endpoint); err != nil {
+		t.Fatalf("SaveEndpoint() error = %v", err)
+	}
+	t.Setenv(endpointFileEnv, path)
+	t.Setenv(omniURIEnv, "")
 
 	_, err := NewLazyRuntimeFromEnvOrStart(BackendEmulator)
 	if err == nil {
 		t.Fatal("NewLazyRuntimeFromEnvOrStart() error = nil, want non-nil")
+	}
+}
+
+func TestEndpointConfiguredForBackend(t *testing.T) {
+	t.Setenv(endpointFileEnv, "")
+	t.Setenv(omniURIEnv, "")
+	t.Setenv(emulatorURIEnv, "")
+
+	if EndpointConfiguredForBackend(BackendOmni) {
+		t.Fatal("EndpointConfiguredForBackend(Omni) = true, want false")
+	}
+	t.Setenv(emulatorURIEnv, "127.0.0.1:9010")
+	if EndpointConfiguredForBackend(BackendOmni) {
+		t.Fatal("EndpointConfiguredForBackend(Omni) with emulator URI = true, want false")
+	}
+	if !EndpointConfiguredForBackend(BackendEmulator) {
+		t.Fatal("EndpointConfiguredForBackend(Emulator) = false, want true")
+	}
+}
+
+func TestLoadEndpointForBackendSelectsMatchingURIEnv(t *testing.T) {
+	t.Setenv(endpointFileEnv, "")
+	t.Setenv(omniURIEnv, "127.0.0.1:15000")
+	t.Setenv(emulatorURIEnv, "127.0.0.1:9010")
+
+	omni, err := LoadEndpointForBackend(BackendOmni)
+	if err != nil {
+		t.Fatalf("LoadEndpointForBackend(Omni) error = %v", err)
+	}
+	if omni.URI != "127.0.0.1:15000" {
+		t.Fatalf("Omni URI = %q, want 127.0.0.1:15000", omni.URI)
+	}
+
+	emulator, err := LoadEndpointForBackend(BackendEmulator)
+	if err != nil {
+		t.Fatalf("LoadEndpointForBackend(Emulator) error = %v", err)
+	}
+	if emulator.URI != "127.0.0.1:9010" {
+		t.Fatalf("Emulator URI = %q, want 127.0.0.1:9010", emulator.URI)
+	}
+}
+
+func TestAttachedRuntimeInheritedOptionsPreservesConstructorBootstrap(t *testing.T) {
+	runtime, err := NewAttachedRuntime(Endpoint{
+		Backend:    BackendOmni,
+		URI:        "127.0.0.1:15000",
+		ProjectID:  defaultOmniProjectID,
+		InstanceID: defaultOmniInstanceID,
+	},
+		WithRandomDatabaseID(),
+		WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}),
+		WithSetupRawDMLs([]string{"INSERT INTO tbl (pk) VALUES ('x')"}),
+	)
+	if err != nil {
+		t.Fatalf("NewAttachedRuntime() error = %v", err)
+	}
+	opts, err := runtime.inheritedOptions()
+	if err != nil {
+		t.Fatalf("inheritedOptions() error = %v", err)
+	}
+	if opts.disableCreateDatabase {
+		t.Fatal("disableCreateDatabase = true, want false for WithRandomDatabaseID")
+	}
+	if len(opts.setupDDLs) != 1 {
+		t.Fatalf("len(setupDDLs) = %d, want 1", len(opts.setupDDLs))
+	}
+	if len(opts.setupDMLs) != 1 {
+		t.Fatalf("len(setupDMLs) = %d, want 1", len(opts.setupDMLs))
+	}
+}
+
+func TestParseStopArgs(t *testing.T) {
+	cfg, err := ParseStopArgs([]string{"--endpoint-file", "/tmp/omni.json"})
+	if err != nil {
+		t.Fatalf("ParseStopArgs() error = %v", err)
+	}
+	if cfg.EndpointFile != "/tmp/omni.json" {
+		t.Fatalf("EndpointFile = %q, want /tmp/omni.json", cfg.EndpointFile)
+	}
+}
+
+func TestParseServeArgsRequiresBackend(t *testing.T) {
+	_, err := ParseServeArgs([]string{"--endpoint-file", "/tmp/omni.json"})
+	if err == nil {
+		t.Fatal("ParseServeArgs() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "usage:") {
+		t.Fatalf("ParseServeArgs() error = %v, want usage error", err)
 	}
 }
 

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"google.golang.org/api/option"
 )
 
 func TestLoadEndpointFromFile(t *testing.T) {
@@ -198,6 +200,58 @@ func TestNewLazyRuntimeFromEnvOrStartRejectsBackendMismatch(t *testing.T) {
 	_, err := NewLazyRuntimeFromEnvOrStart(BackendEmulator)
 	if err == nil {
 		t.Fatal("NewLazyRuntimeFromEnvOrStart() error = nil, want non-nil")
+	}
+}
+
+func TestEndpointFromRuntimeRejectsInvalidEndpoint(t *testing.T) {
+	runtime := &invalidEndpointRuntime{}
+	_, err := EndpointFromRuntime(runtime)
+	if err == nil {
+		t.Fatal("EndpointFromRuntime() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "project_id") {
+		t.Fatalf("EndpointFromRuntime() error = %v, want project_id validation error", err)
+	}
+}
+
+type invalidEndpointRuntime struct{}
+
+func (*invalidEndpointRuntime) spanemuboostRuntime()                 {}
+func (*invalidEndpointRuntime) URI() string                          { return "127.0.0.1:1" }
+func (*invalidEndpointRuntime) ClientOptions() []option.ClientOption { return nil }
+func (*invalidEndpointRuntime) Close() error                         { return nil }
+func (*invalidEndpointRuntime) ProjectID() string                    { return "" }
+func (*invalidEndpointRuntime) InstanceID() string                   { return "" }
+func (*invalidEndpointRuntime) DatabaseID() string                   { return "" }
+func (*invalidEndpointRuntime) ProjectPath() string                  { return "" }
+func (*invalidEndpointRuntime) InstancePath() string                 { return "" }
+func (*invalidEndpointRuntime) DatabasePath() string                 { return "" }
+
+func TestAttachedRuntimeNilReceiverSafe(t *testing.T) {
+	var runtime *AttachedRuntime
+	if got := runtime.URI(); got != "" {
+		t.Fatalf("URI() = %q, want empty", got)
+	}
+	if got := runtime.ClientOptions(); got != nil {
+		t.Fatalf("ClientOptions() = %v, want nil", got)
+	}
+	if got := runtime.ProjectID(); got != "" {
+		t.Fatalf("ProjectID() = %q, want empty", got)
+	}
+	if got := runtime.InstanceID(); got != "" {
+		t.Fatalf("InstanceID() = %q, want empty", got)
+	}
+	if got := runtime.DatabaseID(); got != "" {
+		t.Fatalf("DatabaseID() = %q, want empty", got)
+	}
+	if got := runtime.ProjectPath(); got != "" {
+		t.Fatalf("ProjectPath() = %q, want empty", got)
+	}
+	if got := runtime.InstancePath(); got != "" {
+		t.Fatalf("InstancePath() = %q, want empty", got)
+	}
+	if got := runtime.DatabasePath(); got != "" {
+		t.Fatalf("DatabasePath() = %q, want empty", got)
 	}
 }
 

--- a/lazy.go
+++ b/lazy.go
@@ -84,7 +84,7 @@ func NewLazyRuntime(backend Backend, options ...Option) *LazyRuntime {
 func (lr *LazyRuntime) get(ctx context.Context) (runtimeInstance, error) {
 	return lr.state.get(ctx, func(ctx context.Context) (runtimeInstance, error) {
 		if lr.attachedEndpoint != nil {
-			return NewAttachedRuntime(*lr.attachedEndpoint)
+			return NewAttachedRuntime(*lr.attachedEndpoint, lr.opts...)
 		}
 		runtime, err := Run(ctx, lr.backend, lr.opts...)
 		if err != nil {

--- a/lazy.go
+++ b/lazy.go
@@ -66,6 +66,8 @@ type LazyRuntime struct {
 	state   lazyRuntimeState
 	backend Backend
 	opts    []Option
+
+	attachedEndpoint *Endpoint
 }
 
 func (*LazyRuntime) spanemuboostRuntime() {}
@@ -81,6 +83,9 @@ func NewLazyRuntime(backend Backend, options ...Option) *LazyRuntime {
 
 func (lr *LazyRuntime) get(ctx context.Context) (runtimeInstance, error) {
 	return lr.state.get(ctx, func(ctx context.Context) (runtimeInstance, error) {
+		if lr.attachedEndpoint != nil {
+			return NewAttachedRuntime(*lr.attachedEndpoint)
+		}
 		runtime, err := Run(ctx, lr.backend, lr.opts...)
 		if err != nil {
 			return nil, err

--- a/omni_attached_test.go
+++ b/omni_attached_test.go
@@ -15,9 +15,9 @@ func TestAttachedOmniClientsFromEnv(t *testing.T) {
 		t.Skip("set SPANEMUBOOST_ENDPOINT_FILE or SPANEMUBOOST_OMNI_URI to run attached Omni tests")
 	}
 
-	lazy, err := NewLazyRuntimeOptionalEndpoint(BackendOmni)
+	lazy, err := NewLazyRuntimeFromEnvOrStart(BackendOmni)
 	if err != nil {
-		t.Fatalf("NewLazyRuntimeOptionalEndpoint() error = %v", err)
+		t.Fatalf("NewLazyRuntimeFromEnvOrStart() error = %v", err)
 	}
 	clients := SetupClients(t, lazy,
 		WithRandomDatabaseID(),

--- a/omni_attached_test.go
+++ b/omni_attached_test.go
@@ -11,7 +11,7 @@ func TestAttachedOmniClientsFromEnv(t *testing.T) {
 	if os.Getenv("SPANEMUBOOST_ENABLE_OMNI_TESTS") == "" {
 		t.Skip("set SPANEMUBOOST_ENABLE_OMNI_TESTS=1 to run Spanner Omni tests")
 	}
-	if !EndpointConfigured() {
+	if !EndpointConfiguredForBackend(BackendOmni) {
 		t.Skip("set SPANEMUBOOST_ENDPOINT_FILE or SPANEMUBOOST_OMNI_URI to run attached Omni tests")
 	}
 

--- a/omni_attached_test.go
+++ b/omni_attached_test.go
@@ -1,0 +1,39 @@
+package spanemuboost
+
+import (
+	"os"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+)
+
+func TestAttachedOmniClientsFromEnv(t *testing.T) {
+	if os.Getenv("SPANEMUBOOST_ENABLE_OMNI_TESTS") == "" {
+		t.Skip("set SPANEMUBOOST_ENABLE_OMNI_TESTS=1 to run Spanner Omni tests")
+	}
+	if !EndpointConfigured() {
+		t.Skip("set SPANEMUBOOST_ENDPOINT_FILE or SPANEMUBOOST_OMNI_URI to run attached Omni tests")
+	}
+
+	lazy := NewLazyRuntimeOptionalEndpoint(BackendOmni)
+	clients := SetupClients(t, lazy,
+		WithRandomDatabaseID(),
+		WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX), col INT64) PRIMARY KEY (pk)"}),
+		WithSetupRawDMLs([]string{"INSERT INTO tbl (pk, col) VALUES ('attached', 3)"}),
+	)
+
+	iter := clients.Client.Single().Query(t.Context(), spanner.NewStatement("SELECT col FROM tbl WHERE pk = 'attached'"))
+	err := iter.Do(func(r *spanner.Row) error {
+		var col int64
+		if err := r.Column(0, &col); err != nil {
+			return err
+		}
+		if col != 3 {
+			t.Fatalf("col = %d, want 3", col)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/omni_attached_test.go
+++ b/omni_attached_test.go
@@ -15,7 +15,10 @@ func TestAttachedOmniClientsFromEnv(t *testing.T) {
 		t.Skip("set SPANEMUBOOST_ENDPOINT_FILE or SPANEMUBOOST_OMNI_URI to run attached Omni tests")
 	}
 
-	lazy := NewLazyRuntimeOptionalEndpoint(BackendOmni)
+	lazy, err := NewLazyRuntimeOptionalEndpoint(BackendOmni)
+	if err != nil {
+		t.Fatalf("NewLazyRuntimeOptionalEndpoint() error = %v", err)
+	}
 	clients := SetupClients(t, lazy,
 		WithRandomDatabaseID(),
 		WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX), col INT64) PRIMARY KEY (pk)"}),
@@ -23,7 +26,7 @@ func TestAttachedOmniClientsFromEnv(t *testing.T) {
 	)
 
 	iter := clients.Client.Single().Query(t.Context(), spanner.NewStatement("SELECT col FROM tbl WHERE pk = 'attached'"))
-	err := iter.Do(func(r *spanner.Row) error {
+	err = iter.Do(func(r *spanner.Row) error {
 		var col int64
 		if err := r.Column(0, &col); err != nil {
 			return err

--- a/omni_timing_test.go
+++ b/omni_timing_test.go
@@ -17,7 +17,10 @@ func TestOmniRuntimeAttachTiming(t *testing.T) {
 	}
 
 	start := time.Now()
-	lazy := NewLazyRuntimeOptionalEndpoint(BackendOmni)
+	lazy, err := NewLazyRuntimeOptionalEndpoint(BackendOmni)
+	if err != nil {
+		t.Fatalf("NewLazyRuntimeOptionalEndpoint() error = %v", err)
+	}
 	clients := SetupClients(t, lazy,
 		WithRandomDatabaseID(),
 		WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}),

--- a/omni_timing_test.go
+++ b/omni_timing_test.go
@@ -1,0 +1,46 @@
+//go:build omni_bench
+
+package spanemuboost
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestOmniRuntimeAttachTiming(t *testing.T) {
+	if os.Getenv("SPANEMUBOOST_ENABLE_OMNI_TESTS") == "" {
+		t.Skip("set SPANEMUBOOST_ENABLE_OMNI_TESTS=1")
+	}
+	if !EndpointConfigured() {
+		t.Skip("set SPANEMUBOOST_ENDPOINT_FILE or SPANEMUBOOST_OMNI_URI for attached timing")
+	}
+
+	start := time.Now()
+	lazy := NewLazyRuntimeOptionalEndpoint(BackendOmni)
+	clients := SetupClients(t, lazy,
+		WithRandomDatabaseID(),
+		WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}),
+	)
+	t.Logf("attached omni client setup: %s", time.Since(start))
+	_ = clients
+}
+
+func TestOmniRuntimeColdStartTiming(t *testing.T) {
+	if os.Getenv("SPANEMUBOOST_ENABLE_OMNI_TESTS") == "" {
+		t.Skip("set SPANEMUBOOST_ENABLE_OMNI_TESTS=1")
+	}
+	if EndpointConfigured() {
+		t.Skip("unset SPANEMUBOOST_ENDPOINT_FILE and SPANEMUBOOST_OMNI_URI for cold-start timing")
+	}
+
+	start := time.Now()
+	lazy := NewLazyRuntime(BackendOmni)
+	t.Cleanup(func() { _ = lazy.Close() })
+	clients := SetupClients(t, lazy,
+		WithRandomDatabaseID(),
+		WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}),
+	)
+	t.Logf("cold omni container startup + client setup: %s", time.Since(start))
+	_ = clients
+}

--- a/omni_timing_test.go
+++ b/omni_timing_test.go
@@ -17,9 +17,9 @@ func TestOmniRuntimeAttachTiming(t *testing.T) {
 	}
 
 	start := time.Now()
-	lazy, err := NewLazyRuntimeOptionalEndpoint(BackendOmni)
+	lazy, err := NewLazyRuntimeFromEnvOrStart(BackendOmni)
 	if err != nil {
-		t.Fatalf("NewLazyRuntimeOptionalEndpoint() error = %v", err)
+		t.Fatalf("NewLazyRuntimeFromEnvOrStart() error = %v", err)
 	}
 	clients := SetupClients(t, lazy,
 		WithRandomDatabaseID(),

--- a/runtime.go
+++ b/runtime.go
@@ -35,8 +35,8 @@ const (
 // and [SetupClients].
 //
 // Supported handles are started [Runtime] values returned by [Run] or [Setup],
-// as well as [*Emulator], [*LazyRuntime], and [*LazyEmulator]. External
-// implementations are not supported.
+// as well as [*Emulator], [*LazyRuntime], [*LazyEmulator], and
+// [*AttachedRuntime]. External implementations are not supported.
 type RuntimeHandle interface {
 	spanemuboostRuntime()
 }
@@ -133,6 +133,11 @@ func resolveRuntime(ctx context.Context, runtime RuntimeHandle) (runtimeInstance
 			return nil, errors.New("spanemuboost: runtime is a nil *LazyEmulator")
 		}
 		return r.get(ctx)
+	case *AttachedRuntime:
+		if r == nil {
+			return nil, errors.New("spanemuboost: runtime is a nil *AttachedRuntime")
+		}
+		return r, nil
 	case Runtime:
 		if isNilRuntimeValue(r) {
 			return nil, fmt.Errorf("spanemuboost: runtime is a nil %T", r)
@@ -141,6 +146,8 @@ func resolveRuntime(ctx context.Context, runtime RuntimeHandle) (runtimeInstance
 		case *Emulator:
 			return instance, nil
 		case *omniRuntime:
+			return instance, nil
+		case *AttachedRuntime:
 			return instance, nil
 		default:
 			return nil, fmt.Errorf("spanemuboost: unsupported runtime type %T; use *Emulator, *LazyRuntime, *LazyEmulator, or a Runtime returned by Run or Setup", runtime)

--- a/runtime.go
+++ b/runtime.go
@@ -72,7 +72,8 @@ type runtimeInstance interface {
 // "linux/amd64", "linux/arm64", or, when available, a variant-qualified value
 // such as "linux/arm64/v8") for a package-provided runtime handle.
 // When the underlying runtime only exposes partial metadata, it may return an
-// OS-only value such as "linux".
+// OS-only value such as "linux". [AttachedRuntime] values return "attached"
+// because they do not own a container.
 //
 // It accepts the same started and lazy handles as [OpenClients] and
 // [SetupClients], and resolves lazy handles by starting them on first use.

--- a/serve.go
+++ b/serve.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 )
 
-// Serve starts a backend runtime, writes its [Endpoint] metadata, and blocks
-// until ctx is canceled. The runtime is closed before Serve returns.
+// Serve starts a backend runtime, writes its [Endpoint] metadata when endpointPath
+// is non-empty, and blocks until ctx is canceled. The runtime is closed before
+// Serve returns. When an endpoint file was written, it is removed on exit so
+// stale metadata is not left behind.
 func Serve(ctx context.Context, backend Backend, endpointPath string, options ...Option) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -30,12 +30,15 @@ func Serve(ctx context.Context, backend Backend, endpointPath string, options ..
 		if err := SaveEndpoint(endpointPath, endpoint); err != nil {
 			return err
 		}
+		defer func() {
+			if err := os.Remove(endpointPath); err != nil && !os.IsNotExist(err) {
+				logCloseError("remove endpoint file after serve", err)
+			}
+		}()
 	}
 
-	serveCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
-	defer stop()
-	<-serveCtx.Done()
-	if err := serveCtx.Err(); err != nil && err != context.Canceled {
+	<-ctx.Done()
+	if err := ctx.Err(); err != nil && err != context.Canceled {
 		return err
 	}
 	return nil

--- a/serve.go
+++ b/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 )
 
 // Serve starts a backend runtime, writes its [Endpoint] metadata when endpointPath
@@ -26,6 +27,9 @@ func Serve(ctx context.Context, backend Backend, endpointPath string, options ..
 	if err != nil {
 		return err
 	}
+	endpoint.ManagedBy = "spanemuboost serve"
+	endpoint.PID = os.Getpid()
+	endpoint.StartedAt = time.Now().UTC().Format(time.RFC3339)
 	if endpointPath != "" {
 		if err := SaveEndpoint(endpointPath, endpoint); err != nil {
 			return err
@@ -44,19 +48,30 @@ func Serve(ctx context.Context, backend Backend, endpointPath string, options ..
 	return nil
 }
 
-// ServeConfig configures [ServeFromArgs].
+// ServeConfig configures [ServeFromConfig].
 type ServeConfig struct {
 	Backend      Backend
 	EndpointFile string
+	PIDFile      string
 	Options      []Option
 }
 
 // ServeFromConfig starts a backend and blocks until interrupted.
 func ServeFromConfig(ctx context.Context, cfg ServeConfig) error {
+	if cfg.PIDFile != "" {
+		if err := os.WriteFile(cfg.PIDFile, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o600); err != nil {
+			return fmt.Errorf("spanemuboost: write pid file %q: %w", cfg.PIDFile, err)
+		}
+		defer func() {
+			if err := os.Remove(cfg.PIDFile); err != nil && !os.IsNotExist(err) {
+				logCloseError("remove pid file after serve", err)
+			}
+		}()
+	}
 	return Serve(ctx, cfg.Backend, cfg.EndpointFile, cfg.Options...)
 }
 
-// ParseServeArgs parses `spanemuboost serve <emulator|omni> [--endpoint-file path]`.
+// ParseServeArgs parses `spanemuboost serve <emulator|omni> --endpoint-file path [--pid-file path]`.
 func ParseServeArgs(args []string) (ServeConfig, error) {
 	cfg := ServeConfig{}
 	var backend string
@@ -68,6 +83,12 @@ func ParseServeArgs(args []string) (ServeConfig, error) {
 			}
 			cfg.EndpointFile = args[i+1]
 			i++
+		case "--pid-file":
+			if i+1 >= len(args) {
+				return ServeConfig{}, fmt.Errorf("--pid-file requires a value")
+			}
+			cfg.PIDFile = args[i+1]
+			i++
 		case "emulator", "omni":
 			if backend != "" {
 				return ServeConfig{}, fmt.Errorf("multiple backends specified: %q and %q", backend, args[i])
@@ -78,7 +99,7 @@ func ParseServeArgs(args []string) (ServeConfig, error) {
 		}
 	}
 	if backend == "" {
-		return ServeConfig{}, fmt.Errorf("usage: spanemuboost serve <emulator|omni> [--endpoint-file path]")
+		return ServeConfig{}, fmt.Errorf("usage: spanemuboost serve <emulator|omni> --endpoint-file path [--pid-file path]")
 	}
 	switch Backend(backend) {
 	case BackendEmulator:

--- a/serve.go
+++ b/serve.go
@@ -1,0 +1,89 @@
+package spanemuboost
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// Serve starts a backend runtime, writes its [Endpoint] metadata, and blocks
+// until ctx is canceled. The runtime is closed before Serve returns.
+func Serve(ctx context.Context, backend Backend, endpointPath string, options ...Option) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	runtime, err := Run(ctx, backend, options...)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		logCloseError("close runtime after serve", runtime.Close())
+	}()
+
+	endpoint, err := EndpointFromRuntime(runtime)
+	if err != nil {
+		return err
+	}
+	if endpointPath != "" {
+		if err := SaveEndpoint(endpointPath, endpoint); err != nil {
+			return err
+		}
+	}
+
+	serveCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	<-serveCtx.Done()
+	if err := serveCtx.Err(); err != nil && err != context.Canceled {
+		return err
+	}
+	return nil
+}
+
+// ServeConfig configures [ServeFromArgs].
+type ServeConfig struct {
+	Backend      Backend
+	EndpointFile string
+	Options      []Option
+}
+
+// ServeFromConfig starts a backend and blocks until interrupted.
+func ServeFromConfig(ctx context.Context, cfg ServeConfig) error {
+	return Serve(ctx, cfg.Backend, cfg.EndpointFile, cfg.Options...)
+}
+
+// ParseServeArgs parses `spanemuboost serve <emulator|omni> [--endpoint-file path]`.
+func ParseServeArgs(args []string) (ServeConfig, error) {
+	cfg := ServeConfig{}
+	var backend string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--endpoint-file", "-o":
+			if i+1 >= len(args) {
+				return ServeConfig{}, fmt.Errorf("--endpoint-file requires a value")
+			}
+			cfg.EndpointFile = args[i+1]
+			i++
+		case "emulator", "omni":
+			if backend != "" {
+				return ServeConfig{}, fmt.Errorf("multiple backends specified: %q and %q", backend, args[i])
+			}
+			backend = args[i]
+		default:
+			return ServeConfig{}, fmt.Errorf("unknown argument %q", args[i])
+		}
+	}
+	if backend == "" {
+		return ServeConfig{}, fmt.Errorf("usage: spanemuboost serve <emulator|omni> [--endpoint-file path]")
+	}
+	switch Backend(backend) {
+	case BackendEmulator:
+		cfg.Backend = BackendEmulator
+	case BackendOmni:
+		cfg.Backend = BackendOmni
+	default:
+		return ServeConfig{}, fmt.Errorf("unsupported serve backend %q; supported values are emulator and omni", backend)
+	}
+	return cfg, nil
+}

--- a/stop.go
+++ b/stop.go
@@ -1,0 +1,139 @@
+package spanemuboost
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const defaultStopTimeout = 30 * time.Second
+
+// StopConfig configures [StopFromConfig].
+type StopConfig struct {
+	EndpointFile string
+	PIDFile      string
+	Timeout      time.Duration
+}
+
+// StopFromConfig sends SIGTERM to a spanemuboost serve process and waits for it
+// to exit. The process is identified by StopConfig.PIDFile or lifecycle metadata
+// in StopConfig.EndpointFile. Remote or manually started endpoints without a PID
+// cannot be stopped through this API.
+func StopFromConfig(ctx context.Context, cfg StopConfig) error {
+	pid, err := resolveServePID(cfg)
+	if err != nil {
+		return err
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultStopTimeout
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("spanemuboost: find serve process %d: %w", pid, err)
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("spanemuboost: signal serve process %d: %w", pid, err)
+	}
+
+	deadline := time.Now().Add(cfg.Timeout)
+	for time.Now().Before(deadline) {
+		if err := proc.Signal(syscall.Signal(0)); err != nil {
+			return waitForEndpointCleanup(ctx, cfg.EndpointFile, deadline)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+	if err := proc.Signal(syscall.SIGKILL); err == nil {
+		for time.Now().Before(deadline) {
+			if err := proc.Signal(syscall.Signal(0)); err != nil {
+				return waitForEndpointCleanup(ctx, cfg.EndpointFile, deadline)
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	}
+
+	return fmt.Errorf("spanemuboost: serve process %d did not exit within %s", pid, cfg.Timeout)
+}
+
+func resolveServePID(cfg StopConfig) (int, error) {
+	if path := strings.TrimSpace(cfg.PIDFile); path != "" {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return 0, fmt.Errorf("spanemuboost: read pid file %q: %w", path, err)
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil || pid <= 0 {
+			return 0, fmt.Errorf("spanemuboost: invalid pid in %q", path)
+		}
+		return pid, nil
+	}
+	if path := strings.TrimSpace(cfg.EndpointFile); path != "" {
+		endpoint, err := ReadEndpointFile(path)
+		if err != nil {
+			return 0, err
+		}
+		if endpoint.PID <= 0 {
+			return 0, fmt.Errorf("spanemuboost: endpoint file %q has no managed serve pid", path)
+		}
+		return endpoint.PID, nil
+	}
+	return 0, fmt.Errorf("spanemuboost: --endpoint-file or --pid-file is required")
+}
+
+func waitForEndpointCleanup(ctx context.Context, endpointPath string, deadline time.Time) error {
+	path := strings.TrimSpace(endpointPath)
+	if path == "" {
+		return nil
+	}
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	return fmt.Errorf("spanemuboost: endpoint file %q still exists after serve stopped", path)
+}
+
+// ParseStopArgs parses `spanemuboost stop --endpoint-file path [--pid-file path]`.
+func ParseStopArgs(args []string) (StopConfig, error) {
+	cfg := StopConfig{}
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--endpoint-file", "-o":
+			if i+1 >= len(args) {
+				return StopConfig{}, fmt.Errorf("--endpoint-file requires a value")
+			}
+			cfg.EndpointFile = args[i+1]
+			i++
+		case "--pid-file":
+			if i+1 >= len(args) {
+				return StopConfig{}, fmt.Errorf("--pid-file requires a value")
+			}
+			cfg.PIDFile = args[i+1]
+			i++
+		default:
+			return StopConfig{}, fmt.Errorf("unknown argument %q", args[i])
+		}
+	}
+	if cfg.EndpointFile == "" && cfg.PIDFile == "" {
+		return StopConfig{}, fmt.Errorf("usage: spanemuboost stop --endpoint-file path [--pid-file path]")
+	}
+	return cfg, nil
+}

--- a/stop.go
+++ b/stop.go
@@ -2,6 +2,7 @@ package spanemuboost
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -37,13 +38,16 @@ func StopFromConfig(ctx context.Context, cfg StopConfig) error {
 		return fmt.Errorf("spanemuboost: find serve process %d: %w", pid, err)
 	}
 	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		if isProcessDone(err) {
+			return finishStopCleanup(cfg)
+		}
 		return fmt.Errorf("spanemuboost: signal serve process %d: %w", pid, err)
 	}
 
 	deadline := time.Now().Add(cfg.Timeout)
 	for time.Now().Before(deadline) {
 		if err := proc.Signal(syscall.Signal(0)); err != nil {
-			return waitForEndpointCleanup(ctx, cfg.EndpointFile, deadline)
+			return finishStopCleanup(cfg)
 		}
 		select {
 		case <-ctx.Done():
@@ -55,7 +59,7 @@ func StopFromConfig(ctx context.Context, cfg StopConfig) error {
 	if err := proc.Signal(syscall.SIGKILL); err == nil {
 		for time.Now().Before(deadline) {
 			if err := proc.Signal(syscall.Signal(0)); err != nil {
-				return waitForEndpointCleanup(ctx, cfg.EndpointFile, deadline)
+				return finishStopCleanup(cfg)
 			}
 			select {
 			case <-ctx.Done():
@@ -66,6 +70,16 @@ func StopFromConfig(ctx context.Context, cfg StopConfig) error {
 	}
 
 	return fmt.Errorf("spanemuboost: serve process %d did not exit within %s", pid, cfg.Timeout)
+}
+
+func finishStopCleanup(cfg StopConfig) error {
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	return waitForEndpointCleanup(cleanupCtx, cfg, time.Now().Add(time.Second))
+}
+
+func isProcessDone(err error) bool {
+	return errors.Is(err, os.ErrProcessDone) || strings.Contains(err.Error(), "no such process")
 }
 
 func resolveServePID(cfg StopConfig) (int, error) {
@@ -93,22 +107,33 @@ func resolveServePID(cfg StopConfig) (int, error) {
 	return 0, fmt.Errorf("spanemuboost: --endpoint-file or --pid-file is required")
 }
 
-func waitForEndpointCleanup(ctx context.Context, endpointPath string, deadline time.Time) error {
-	path := strings.TrimSpace(endpointPath)
-	if path == "" {
+func waitForEndpointCleanup(ctx context.Context, cfg StopConfig, deadline time.Time) error {
+	if path := strings.TrimSpace(cfg.PIDFile); path != "" {
+		_ = os.Remove(path)
+	}
+	endpointPath := strings.TrimSpace(cfg.EndpointFile)
+	if endpointPath == "" {
 		return nil
 	}
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(path); os.IsNotExist(err) {
+	cleanupDeadline := time.Now().Add(time.Second)
+	if cleanupDeadline.After(deadline) {
+		cleanupDeadline = deadline
+	}
+	for time.Now().Before(cleanupDeadline) {
+		if _, err := os.Stat(endpointPath); os.IsNotExist(err) {
 			return nil
 		}
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(100 * time.Millisecond):
+			goto removeStale
+		case <-time.After(50 * time.Millisecond):
 		}
 	}
-	return fmt.Errorf("spanemuboost: endpoint file %q still exists after serve stopped", path)
+removeStale:
+	if err := os.Remove(endpointPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("spanemuboost: remove stale endpoint file %q: %w", endpointPath, err)
+	}
+	return nil
 }
 
 // ParseStopArgs parses `spanemuboost stop --endpoint-file path [--pid-file path]`.

--- a/stop_test.go
+++ b/stop_test.go
@@ -1,0 +1,41 @@
+package spanemuboost
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStopFromConfigCleansStaleEndpointWhenProcessDead(t *testing.T) {
+	dir := t.TempDir()
+	endpointPath := filepath.Join(dir, "endpoint.json")
+	pidPath := filepath.Join(dir, "serve.pid")
+	endpoint := Endpoint{
+		Backend:    BackendOmni,
+		URI:        "127.0.0.1:15000",
+		ProjectID:  defaultOmniProjectID,
+		InstanceID: defaultOmniInstanceID,
+		ManagedBy:  "spanemuboost serve",
+		PID:        999999,
+	}
+	if err := SaveEndpoint(endpointPath, endpoint); err != nil {
+		t.Fatalf("SaveEndpoint() error = %v", err)
+	}
+	if err := os.WriteFile(pidPath, []byte("999999\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(pid) error = %v", err)
+	}
+
+	if err := StopFromConfig(context.Background(), StopConfig{
+		EndpointFile: endpointPath,
+		PIDFile:      pidPath,
+	}); err != nil {
+		t.Fatalf("StopFromConfig() error = %v", err)
+	}
+	if _, err := os.Stat(endpointPath); !os.IsNotExist(err) {
+		t.Fatalf("endpoint file still exists: err=%v", err)
+	}
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Fatalf("pid file still exists: err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `Endpoint` metadata with JSON file and env loading (`SPANEMUBOOST_ENDPOINT_FILE`, `SPANEMUBOOST_OMNI_URI`, `SPANEMUBOOST_EMULATOR_URI`, and optional project/instance overrides)
- Add `AttachedRuntime`, `NewAttachedRuntime`, and `NewAttachedRuntimeFromEnv` so clients can attach to an already-running Omni or emulator backend without starting testcontainers
- Add `NewLazyRuntimeFromEnvOrStart` to attach when endpoint env vars are set for the requested backend, or defer cold container startup otherwise; `LazyRuntime` resolves to the attached path on first use
- Add `spanemuboost serve` / `spanemuboost stop` CLI (plus programmatic `Serve`, `ServeFromConfig`, `StopFromConfig`, and arg parsers) to manage long-lived emulator or Omni backends and publish reusable endpoint JSON
- Write lifecycle metadata (`managed_by`, `pid`, `started_at`) into endpoint files for coordinated shutdown; support optional `--pid-file` on serve/stop
- Add backend-aware `LoadEndpointForBackend` and `EndpointConfiguredForBackend` so Omni and emulator endpoints do not collide
- Document the long-lived Omni reuse workflow in README
- Preserve backward compatibility: existing `NewLazyRuntime` / testcontainers paths are unchanged when no endpoint env vars are set

## Architecture

- **Lifecycle manager**: `spanemuboost serve <emulator|omni> --endpoint-file /tmp/omni.json` starts one container, writes connection metadata (including the serve process PID), and removes the file on exit
- **Stop**: `spanemuboost stop --endpoint-file /tmp/omni.json` signals the serve process (or reads `--pid-file`), waits for exit, and cleans up stale endpoint metadata
- **Client mode**: tests/tools set `SPANEMUBOOST_ENDPOINT_FILE` or backend-specific URI env vars and use `NewLazyRuntimeFromEnvOrStart(BackendOmni)` or `NewAttachedRuntimeFromEnv()`
- **Attached semantics**: `AttachedRuntime.Close` is a no-op; `RuntimePlatform` reports `"attached"` because the handle does not own a container

## Test plan

- [x] `go test ./...`
- [x] Unit tests for endpoint load/save, backend-aware loading, serve/stop arg parsing, attached bootstrap semantics, and stop cleanup when the serve process is already gone
- [x] Opt-in attached Omni integration test (`SPANEMUBOOST_ENABLE_OMNI_TESTS=1` + endpoint env)
- [x] Optional attach vs cold-start timing probes behind the `omni_bench` build tag
- [ ] Manual: start `spanemuboost serve omni`, run Omni integration tests with `SPANEMUBOOST_ENDPOINT_FILE`, and compare startup time vs the cold testcontainers path