### PR TITLE
Fix deprecated clients bootstrap and Omni runtime cleanup semantics

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -471,63 +471,9 @@ func logCloseError(action string, err error) {
 	}
 }
 
-func newClients(ctx context.Context, emulator *tcspanner.Container, opts *emulatorOptions) (clients *Clients, teardown func(), err error) {
-	clientOpts := defaultClientOpts(emulator)
-	instanceCli, err := instance.NewInstanceAdminClient(ctx, clientOpts...)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	instanceCliTeardown := func() {
-		if err := instanceCli.Close(); err != nil {
-			log.Printf("failed to instanceAdminClient.Close(): %v", err)
-		}
-	}
-	teardown = instanceCliTeardown
-
-	dbCli, err := database.NewDatabaseAdminClient(ctx, clientOpts...)
-	if err != nil {
-		teardown()
-		return nil, nil, err
-	}
-
-	dbCliTeardown := func() {
-		if err := dbCli.Close(); err != nil {
-			log.Printf("failed to databaseAdminClient.Close(): %v", err)
-		}
-		instanceCliTeardown()
-	}
-	teardown = dbCliTeardown
-
-	client, err := spanner.NewClientWithConfig(ctx, opts.DatabasePath(), *opts.clientConfig, slices.Concat(clientOpts, opts.clientOptionsForClient)...)
-	if err != nil {
-		teardown()
-		return nil, nil, err
-	}
-
-	teardown = func() {
-		client.Close()
-		dbCliTeardown()
-	}
-
-	return &Clients{
-		InstanceClient: instanceCli,
-		DatabaseClient: dbCli,
-		Client:         client,
-		ProjectID:      opts.projectID,
-		InstanceID:     opts.instanceID,
-		DatabaseID:     opts.databaseID,
-		clientOpts:     clientOpts,
-		uri:            emulator.URI(),
-		dropDatabase:   opts.shouldDropDatabase(),
-		dropInstance:   opts.shouldDropInstance(),
-	}, teardown, nil
-}
-
 // defaultClientOpts returns client options for connecting to the emulator.
-// It is the shared implementation for [Emulator.ClientOptions] and the deprecated
-// newClients path. Once the deprecated path is removed, this function should be
-// inlined into [Emulator.ClientOptions].
+// It is the shared implementation for [Emulator.ClientOptions] and deprecated
+// public helpers that still accept the testcontainers emulator type.
 func defaultClientOpts(emulator *tcspanner.Container) []option.ClientOption {
 	return []option.ClientOption{
 		// passthrough:/// tells gRPC to use the address as-is without DNS resolution.

--- a/internal.go
+++ b/internal.go
@@ -52,7 +52,9 @@ func newEmulator(ctx context.Context, opts *emulatorOptions) (container *tcspann
 	}
 
 	teardown = func() {
-		if err := container.Terminate(context.Background()); err != nil {
+		ctx, cancel := newCloseContext()
+		defer cancel()
+		if err := container.Terminate(ctx); err != nil {
 			log.Printf("failed to terminate Cloud Spanner Emulator: %v", err)
 		}
 	}
@@ -517,6 +519,8 @@ func newClients(ctx context.Context, emulator *tcspanner.Container, opts *emulat
 		DatabaseID:     opts.databaseID,
 		clientOpts:     clientOpts,
 		uri:            emulator.URI(),
+		dropDatabase:   opts.shouldDropDatabase(),
+		dropInstance:   opts.shouldDropInstance(),
 	}, teardown, nil
 }
 

--- a/omni.go
+++ b/omni.go
@@ -3,6 +3,7 @@ package spanemuboost
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -44,9 +46,10 @@ func (o *omniRuntime) URI() string {
 // to the Omni gRPC endpoint without authentication.
 func (o *omniRuntime) ClientOptions() []option.ClientOption {
 	return []option.ClientOption{
-		option.WithEndpoint(o.URI()),
+		option.WithEndpoint("passthrough:///" + o.URI()),
 		option.WithoutAuthentication(),
 		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		internaloption.SkipDialSettingsValidation(),
 	}
 }
 
@@ -122,7 +125,10 @@ func runOmni(ctx context.Context, options ...Option) (Runtime, error) {
 		return nil, err
 	}
 	if err := bootstrapOmni(ctx, omni, opts); err != nil {
-		logCloseError("close omni after bootstrap failure", omni.Close())
+		closeErr := omni.Close()
+		if closeErr != nil {
+			return nil, errors.Join(wrapOmniBootstrapError(err), closeErr)
+		}
 		return nil, wrapOmniBootstrapError(err)
 	}
 	return omni, nil
@@ -140,7 +146,10 @@ func runOmniWithClients(ctx context.Context, options ...Option) (*RuntimeEnv, er
 	}
 	clients, err := bootstrapAndCreateClientsWithOptions(ctx, omni.URI(), opts, omni.ClientOptions())
 	if err != nil {
-		logCloseError("close omni after client creation failure", omni.Close())
+		closeErr := omni.Close()
+		if closeErr != nil {
+			return nil, errors.Join(wrapOmniBootstrapError(err), closeErr)
+		}
 		return nil, wrapOmniBootstrapError(err)
 	}
 
@@ -242,7 +251,9 @@ func startOmni(ctx context.Context, opts *emulatorOptions) (*omniRuntime, error)
 	if err != nil {
 		// Cleanup must still run if setup failed because ctx was canceled or
 		// timed out, so don't reuse the possibly-dead setup context here.
-		logCloseError("terminate omni container after endpoint lookup failure", container.Terminate(context.Background()))
+		ctx, cancel := newCloseContext()
+		defer cancel()
+		logCloseError("terminate omni container after endpoint lookup failure", container.Terminate(ctx))
 		return nil, err
 	}
 

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
@@ -32,6 +33,8 @@ const (
 // because the emulator container owns the resource lifecycle;
 // use [ForceSchemaTeardown] to override.
 type Clients struct {
+	// InstanceClient enables instance-level administrative operations.
+	// For Omni, instance lifecycle operations are backend-limited and may fail.
 	InstanceClient *instance.InstanceAdminClient
 	DatabaseClient *database.DatabaseAdminClient
 	Client         *spanner.Client
@@ -58,7 +61,7 @@ func (c *Clients) DatabasePath() string { return databasePath(c.ProjectID, c.Ins
 // (e.g., with custom interceptors) against the same emulator without holding a
 // separate [*Emulator] reference.
 func (c *Clients) ClientOptions() []option.ClientOption {
-	return c.clientOpts
+	return slices.Clone(c.clientOpts)
 }
 
 // URI returns the gRPC endpoint (host:port) of the emulator this [Clients]
@@ -240,19 +243,16 @@ func NewEmulatorWithClients(ctx context.Context, options ...Option) (emulator *t
 		return nil, nil, nil, err
 	}
 
-	if err = bootstrap(ctx, opts, defaultClientOpts(emulator)...); err != nil {
-		emulatorTeardown()
-		return nil, nil, nil, err
-	}
-
-	clients, clientsTeardown, err := newClients(ctx, emulator, opts)
+	clients, err = bootstrapAndCreateClientsWithOptions(ctx, emulator.URI(), opts, defaultClientOpts(emulator))
 	if err != nil {
 		emulatorTeardown()
 		return nil, nil, nil, err
 	}
 
 	return emulator, clients, func() {
-		clientsTeardown()
+		if clients != nil {
+			_ = clients.Close()
+		}
 		emulatorTeardown()
 	}, nil
 }
@@ -267,9 +267,14 @@ func NewClients(ctx context.Context, emulator *tcspanner.Container, options ...O
 		return nil, nil, err
 	}
 
-	if err := bootstrap(ctx, opts, defaultClientOpts(emulator)...); err != nil {
+	clients, err = bootstrapAndCreateClientsWithOptions(ctx, emulator.URI(), opts, defaultClientOpts(emulator))
+	if err != nil {
 		return nil, nil, err
 	}
 
-	return newClients(ctx, emulator, opts)
+	return clients, func() {
+		if clients != nil {
+			_ = clients.Close()
+		}
+	}, nil
 }

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -248,10 +248,11 @@ func NewEmulatorWithClients(ctx context.Context, options ...Option) (emulator *t
 		emulatorTeardown()
 		return nil, nil, nil, err
 	}
+	disableSchemaTeardownUnlessForced(opts, clients)
 
 	return emulator, clients, func() {
 		if clients != nil {
-			_ = clients.Close()
+			logCloseError("close clients", clients.Close())
 		}
 		emulatorTeardown()
 	}, nil
@@ -274,7 +275,7 @@ func NewClients(ctx context.Context, emulator *tcspanner.Container, options ...O
 
 	return clients, func() {
 		if clients != nil {
-			_ = clients.Close()
+			logCloseError("close clients", clients.Close())
 		}
 	}, nil
 }

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -2,6 +2,7 @@ package spanemuboost
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -775,6 +776,34 @@ func TestClientsAccessors(t *testing.T) {
 	}
 }
 
+func TestClientsClientOptionsReturnsCopy(t *testing.T) {
+	emu := SetupEmulator(t, EnableInstanceAutoConfigOnly())
+	clients := SetupClients(t, emu,
+		WithRandomDatabaseID(),
+	)
+	defer func() {
+		if err := clients.Close(); err != nil {
+			t.Errorf("failed to close clients: %v", err)
+		}
+	}()
+
+	opts := clients.ClientOptions()
+	if len(opts) == 0 {
+		t.Fatal("ClientOptions() returned empty slice")
+	}
+	before := fmt.Sprintf("%T", opts[0])
+
+	first := opts
+	first[0] = option.WithoutAuthentication()
+	if got := clients.ClientOptions(); len(got) != len(opts) {
+		t.Fatalf("ClientOptions() len = %d, want %d", len(got), len(opts))
+	} else if after := fmt.Sprintf("%T", got[0]); after == before {
+		t.Fatal("ClientOptions() mutation leaked")
+	} else if got[0] == nil {
+		t.Fatal("ClientOptions() mutation leaked")
+	}
+}
+
 func TestRuntimePlatformNilHandle(t *testing.T) {
 	_, err := RuntimePlatform(t.Context(), nil)
 	if err == nil {
@@ -1266,4 +1295,57 @@ func TestNewEmulatorAndNewClientsWithDisableAutoConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewClientsDropFixedResourcesByDefault(t *testing.T) {
+	t.Run("fixed resources dropped by default on Close", func(t *testing.T) {
+		emu := SetupEmulator(t, EnableInstanceAutoConfigOnly())
+		ctx := t.Context()
+		const dbID = "rollback-deprecated-newclients"
+		ddls := []string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}
+
+		clients, _, err := NewClients(ctx, emu.Container(), WithDatabaseID(dbID), WithSetupDDLs(ddls))
+		if err != nil {
+			t.Fatalf("NewClients() error = %v, want nil", err)
+		}
+		if err := clients.Close(); err != nil {
+			t.Fatalf("clients.Close() error = %v, want nil", err)
+		}
+
+		clients2, _, err := NewClients(ctx, emu.Container(), WithDatabaseID(dbID), WithSetupDDLs(ddls))
+		if err != nil {
+			t.Fatalf("second NewClients() error = %v, want nil", err)
+		}
+		defer func() {
+			if err := clients2.Close(); err != nil {
+				t.Errorf("clients2.Close() error = %v", err)
+			}
+		}()
+
+		mustConsumeQuery(t, clients2, "SELECT 1")
+	})
+
+	t.Run("failed setup rolls back created database", func(t *testing.T) {
+		emu := SetupEmulator(t, EnableInstanceAutoConfigOnly())
+		ctx := t.Context()
+		const dbID = "rollback-newclients-on-failure"
+		dmls := []spanner.Statement{spanner.NewStatement("INSERT INTO missing_table (pk) VALUES ('x')")}
+
+		_, _, err := NewClients(ctx, emu.Container(), WithDatabaseID(dbID), WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}), WithSetupDMLs(dmls))
+		if err == nil {
+			t.Fatal("first NewClients() error = nil, want non-nil")
+		}
+
+		clients, _, err := NewClients(ctx, emu.Container(), WithDatabaseID(dbID), WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}))
+		if err != nil {
+			t.Fatalf("second NewClients() error = %v, want nil", err)
+		}
+		defer func() {
+			if err := clients.Close(); err != nil {
+				t.Errorf("clients.Close() error = %v", err)
+			}
+		}()
+
+		mustConsumeQuery(t, clients, "SELECT 1")
+	})
 }

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -794,13 +794,13 @@ func TestClientsClientOptionsReturnsCopy(t *testing.T) {
 	before := fmt.Sprintf("%T", opts[0])
 
 	first := opts
-	first[0] = option.WithoutAuthentication()
+	first[0] = nil
 	if got := clients.ClientOptions(); len(got) != len(opts) {
 		t.Fatalf("ClientOptions() len = %d, want %d", len(got), len(opts))
+	} else if got[0] == nil {
+		t.Fatal("ClientOptions() mutation leaked: first option is nil")
 	} else if after := fmt.Sprintf("%T", got[0]); after != before {
 		t.Fatalf("ClientOptions() mutation leaked: first option type = %s, want %s", after, before)
-	} else if got[0] == nil {
-		t.Fatal("ClientOptions() mutation leaked")
 	}
 }
 

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -797,8 +797,8 @@ func TestClientsClientOptionsReturnsCopy(t *testing.T) {
 	first[0] = option.WithoutAuthentication()
 	if got := clients.ClientOptions(); len(got) != len(opts) {
 		t.Fatalf("ClientOptions() len = %d, want %d", len(got), len(opts))
-	} else if after := fmt.Sprintf("%T", got[0]); after == before {
-		t.Fatal("ClientOptions() mutation leaked")
+	} else if after := fmt.Sprintf("%T", got[0]); after != before {
+		t.Fatalf("ClientOptions() mutation leaked: first option type = %s, want %s", after, before)
 	} else if got[0] == nil {
 		t.Fatal("ClientOptions() mutation leaked")
 	}
@@ -1304,7 +1304,7 @@ func TestNewClientsDropFixedResourcesByDefault(t *testing.T) {
 		const dbID = "rollback-deprecated-newclients"
 		ddls := []string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}
 
-		clients, _, err := NewClients(ctx, emu.Container(), WithDatabaseID(dbID), WithSetupDDLs(ddls))
+		clients, _, err := NewClients(ctx, emu.Container(), EnableDatabaseAutoConfigOnly(), WithDatabaseID(dbID), WithSetupDDLs(ddls))
 		if err != nil {
 			t.Fatalf("NewClients() error = %v, want nil", err)
 		}
@@ -1312,7 +1312,7 @@ func TestNewClientsDropFixedResourcesByDefault(t *testing.T) {
 			t.Fatalf("clients.Close() error = %v, want nil", err)
 		}
 
-		clients2, _, err := NewClients(ctx, emu.Container(), WithDatabaseID(dbID), WithSetupDDLs(ddls))
+		clients2, _, err := NewClients(ctx, emu.Container(), EnableDatabaseAutoConfigOnly(), WithDatabaseID(dbID), WithSetupDDLs(ddls))
 		if err != nil {
 			t.Fatalf("second NewClients() error = %v, want nil", err)
 		}
@@ -1331,12 +1331,12 @@ func TestNewClientsDropFixedResourcesByDefault(t *testing.T) {
 		const dbID = "rollback-newclients-on-failure"
 		dmls := []spanner.Statement{spanner.NewStatement("INSERT INTO missing_table (pk) VALUES ('x')")}
 
-		_, _, err := NewClients(ctx, emu.Container(), WithDatabaseID(dbID), WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}), WithSetupDMLs(dmls))
+		_, _, err := NewClients(ctx, emu.Container(), EnableDatabaseAutoConfigOnly(), WithDatabaseID(dbID), WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}), WithSetupDMLs(dmls))
 		if err == nil {
 			t.Fatal("first NewClients() error = nil, want non-nil")
 		}
 
-		clients, _, err := NewClients(ctx, emu.Container(), WithDatabaseID(dbID), WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}))
+		clients, _, err := NewClients(ctx, emu.Container(), EnableDatabaseAutoConfigOnly(), WithDatabaseID(dbID), WithSetupDDLs([]string{"CREATE TABLE tbl (pk STRING(MAX)) PRIMARY KEY (pk)"}))
 		if err != nil {
 			t.Fatalf("second NewClients() error = %v, want nil", err)
 		}


### PR DESCRIPTION
## Summary
- Route deprecated client bootstrap paths through the unified rollback-capable path so `NewEmulatorWithClients` and `NewClients` behave like modern `OpenClients`.
- Preserve defensive behavior for teardown and ensure default schema-drop behavior is consistent for deprecated API usage.
- Tighten close behavior for Omni startup/teardown paths with bounded cleanup contexts and joined cleanup errors.

## Issues
- Closes #64
- Closes #60
- Closes #40
- Closes #38
- Closes #62
- Closes #37
- Closes #42

## Notes
- `go test ./... -run 'TestClientsClientOptionsReturnsCopy|TestNewClientsDropFixedResourcesByDefault' -count=1` is executed locally, but it requires Docker for emulator-backed tests. In this environment, the Docker socket is not available, so full runtime validation is blocked.
