### PR TITLE
ci: pin lint workflow and include Omni rollback smoke test

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,12 +16,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v1.64.8
           args: --timeout=5m

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,5 +23,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.64.8
+          version: v2.12.2
           args: --timeout=5m

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # CI selection stays easy to audit when smoke coverage changes. Match either the
 # top-level test name or one of its subtests.
 EMULATOR_SMOKE_TEST_PATTERN = ^(TestRunEmulatorWithClients|TestSetupEmulatorAndSetupClients|TestRuntimePlatformWithStartedRuntime|TestLazyRuntimeEmulatorWithSetupClients)($$|/)
-OMNI_SMOKE_TEST_PATTERN = ^(TestRunOmni|TestRunOmniWithClients|TestOpenOmniClients|TestOpenOmniClientsReuseDefaultDatabase|TestOpenOmniClientsAllowDatabaseOverride|TestSetupClientsWithOmni|TestLazyRuntimeWithOmni)($$|/)
+OMNI_SMOKE_TEST_PATTERN = ^(TestRunOmni|TestRunOmniWithClients|TestOpenOmniClients|TestOpenOmniClientsReuseDefaultDatabase|TestOpenOmniClientsAllowDatabaseOverride|TestSetupClientsWithOmni|TestLazyRuntimeWithOmni|TestOpenOmniClientsRollsBackCreatedDatabaseOnFailure)($$|/)
 
 test:
 	go test -v ./...


### PR DESCRIPTION
## Summary
- Pin `golangci-lint` and Go setup in CI workflow for reproducible lint behavior.
- Add `TestOpenOmniClientsRollsBackCreatedDatabaseOnFailure` to the explicit Omni smoke test pattern.

## Issues
- Closes #63
- Closes #43

## Notes
- No behavior tests executed for this change set in this environment (workflow/configuration-only updates).
