### PR TITLE
Serialize admin lifecycle ops and adjust Omni serve bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ spanemuboost serve omni --endpoint-file /tmp/omni-endpoint.json
 spanemuboost stop --endpoint-file /tmp/omni-endpoint.json
 ```
 
+By default, `serve omni` skips instance and database bootstrap so only the
+built-in `spanner-info` database exists until clients create their own. Pass
+`--with-default-database` to create the default `emulator-database` at serve
+time (legacy behavior).
+
 The endpoint file is owned by `serve`: it is written on startup (including the
 serve process PID for lifecycle management) and removed on exit. Unset
 `SPANEMUBOOST_ENDPOINT_FILE` after stopping the lifecycle manager.

--- a/admin_ops.go
+++ b/admin_ops.go
@@ -1,31 +1,41 @@
 package spanemuboost
 
 import (
+	"context"
 	"strings"
 	"sync"
+
+	"golang.org/x/sync/semaphore"
 )
 
 var (
 	instanceAdminMu    sync.Mutex
-	instanceAdminLocks = make(map[string]*sync.Mutex)
+	instanceAdminLocks = make(map[string]*semaphore.Weighted)
 )
 
-func withInstanceAdminLock(instancePath string, fn func()) {
+func withInstanceAdminLock(ctx context.Context, instancePath string, fn func()) error {
 	if instancePath == "" {
 		fn()
-		return
+		return nil
 	}
-	instanceAdminMu.Lock()
-	mu, ok := instanceAdminLocks[instancePath]
-	if !ok {
-		mu = &sync.Mutex{}
-		instanceAdminLocks[instancePath] = mu
+	sem := instanceAdminSemaphore(instancePath)
+	if err := sem.Acquire(ctx, 1); err != nil {
+		return err
 	}
-	instanceAdminMu.Unlock()
-
-	mu.Lock()
-	defer mu.Unlock()
+	defer sem.Release(1)
 	fn()
+	return nil
+}
+
+func instanceAdminSemaphore(instancePath string) *semaphore.Weighted {
+	instanceAdminMu.Lock()
+	defer instanceAdminMu.Unlock()
+	sem, ok := instanceAdminLocks[instancePath]
+	if !ok {
+		sem = semaphore.NewWeighted(1)
+		instanceAdminLocks[instancePath] = sem
+	}
+	return sem
 }
 
 func instancePathFromDatabasePath(dbPath string) string {

--- a/admin_ops.go
+++ b/admin_ops.go
@@ -1,0 +1,37 @@
+package spanemuboost
+
+import (
+	"strings"
+	"sync"
+)
+
+var (
+	instanceAdminMu    sync.Mutex
+	instanceAdminLocks = make(map[string]*sync.Mutex)
+)
+
+func withInstanceAdminLock(instancePath string, fn func()) {
+	if instancePath == "" {
+		fn()
+		return
+	}
+	instanceAdminMu.Lock()
+	mu, ok := instanceAdminLocks[instancePath]
+	if !ok {
+		mu = &sync.Mutex{}
+		instanceAdminLocks[instancePath] = mu
+	}
+	instanceAdminMu.Unlock()
+
+	mu.Lock()
+	defer mu.Unlock()
+	fn()
+}
+
+func instancePathFromDatabasePath(dbPath string) string {
+	const marker = "/databases/"
+	if i := strings.Index(dbPath, marker); i >= 0 {
+		return dbPath[:i]
+	}
+	return dbPath
+}

--- a/admin_ops_test.go
+++ b/admin_ops_test.go
@@ -6,6 +6,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestWithInstanceAdminLockCancelsWhileWaiting(t *testing.T) {
@@ -44,5 +47,17 @@ func TestDropDatabaseRetryBudget(t *testing.T) {
 	}
 	if got := dropDatabaseRetryBudget(); got <= closeTimeout {
 		t.Fatalf("drop retry budget %v must exceed close timeout %v", got, closeTimeout)
+	}
+}
+
+func TestDropDatabaseComplete(t *testing.T) {
+	if !dropDatabaseComplete(nil) {
+		t.Fatal("dropDatabaseComplete(nil) = false, want true")
+	}
+	if !dropDatabaseComplete(status.Error(codes.NotFound, "missing")) {
+		t.Fatal("dropDatabaseComplete(NotFound) = false, want true")
+	}
+	if dropDatabaseComplete(status.Error(codes.Unavailable, "retry")) {
+		t.Fatal("dropDatabaseComplete(Unavailable) = true, want false")
 	}
 }

--- a/admin_ops_test.go
+++ b/admin_ops_test.go
@@ -1,0 +1,48 @@
+package spanemuboost
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWithInstanceAdminLockCancelsWhileWaiting(t *testing.T) {
+	const instancePath = "projects/test/instances/test"
+
+	acquired := make(chan struct{})
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := withInstanceAdminLock(context.Background(), instancePath, func() {
+			close(acquired)
+			<-release
+		}); err != nil {
+			t.Errorf("holder lock: %v", err)
+		}
+	}()
+	<-acquired
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer waitCancel()
+	err := withInstanceAdminLock(waitCtx, instancePath, func() {})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("wait err = %v, want %v", err, context.DeadlineExceeded)
+	}
+
+	close(release)
+	wg.Wait()
+}
+
+func TestDropDatabaseRetryBudget(t *testing.T) {
+	want := dropDatabaseTimeout*time.Duration(dropDatabaseMaxAttempts) + dropDatabaseRetryBackoff
+	if got := dropDatabaseRetryBudget(); got != want {
+		t.Fatalf("dropDatabaseRetryBudget() = %v, want %v", got, want)
+	}
+	if got := dropDatabaseRetryBudget(); got <= closeTimeout {
+		t.Fatalf("drop retry budget %v must exceed close timeout %v", got, closeTimeout)
+	}
+}

--- a/close.go
+++ b/close.go
@@ -2,11 +2,48 @@ package spanemuboost
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"time"
+
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 )
 
 const closeTimeout = 30 * time.Second
+
+const (
+	dropDatabaseTimeout     = 2 * time.Minute
+	dropDatabaseMaxAttempts = 3
+)
+
+func dropDatabaseWithRetry(ctx context.Context, dbCli *database.DatabaseAdminClient, dbPath string) error {
+	if dbCli == nil {
+		return fmt.Errorf("drop database %s: database admin client is nil", dbPath)
+	}
+	instancePath := instancePathFromDatabasePath(dbPath)
+	var lastErr error
+	for attempt := 1; attempt <= dropDatabaseMaxAttempts; attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, dropDatabaseTimeout)
+		withInstanceAdminLock(instancePath, func() {
+			lastErr = dbCli.DropDatabase(attemptCtx, &databasepb.DropDatabaseRequest{Database: dbPath})
+		})
+		cancel()
+		if lastErr == nil {
+			return nil
+		}
+		if attempt == dropDatabaseMaxAttempts {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return errors.Join(fmt.Errorf("drop database %s: %w", dbPath, lastErr), ctx.Err())
+		case <-time.After(time.Duration(attempt) * 5 * time.Second):
+		}
+	}
+	return fmt.Errorf("drop database %s after %d attempts: %w", dbPath, dropDatabaseMaxAttempts, lastErr)
+}
 
 type closeState struct {
 	once sync.Once

--- a/close.go
+++ b/close.go
@@ -14,9 +14,14 @@ import (
 const closeTimeout = 30 * time.Second
 
 const (
-	dropDatabaseTimeout     = 2 * time.Minute
-	dropDatabaseMaxAttempts = 3
+	dropDatabaseTimeout      = 2 * time.Minute
+	dropDatabaseMaxAttempts  = 3
+	dropDatabaseRetryBackoff = 15 * time.Second // 5s + 10s between attempts
 )
+
+func dropDatabaseRetryBudget() time.Duration {
+	return dropDatabaseTimeout*time.Duration(dropDatabaseMaxAttempts) + dropDatabaseRetryBackoff
+}
 
 func dropDatabaseWithRetry(ctx context.Context, dbCli *database.DatabaseAdminClient, dbPath string) error {
 	if dbCli == nil {
@@ -26,10 +31,13 @@ func dropDatabaseWithRetry(ctx context.Context, dbCli *database.DatabaseAdminCli
 	var lastErr error
 	for attempt := 1; attempt <= dropDatabaseMaxAttempts; attempt++ {
 		attemptCtx, cancel := context.WithTimeout(ctx, dropDatabaseTimeout)
-		withInstanceAdminLock(instancePath, func() {
+		lockErr := withInstanceAdminLock(attemptCtx, instancePath, func() {
 			lastErr = dbCli.DropDatabase(attemptCtx, &databasepb.DropDatabaseRequest{Database: dbPath})
 		})
 		cancel()
+		if lockErr != nil {
+			lastErr = lockErr
+		}
 		if lastErr == nil {
 			return nil
 		}
@@ -73,4 +81,8 @@ func ensureCloseState(slot **closeState) *closeState {
 
 func newCloseContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), closeTimeout)
+}
+
+func newDropDatabaseContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), dropDatabaseRetryBudget())
 }

--- a/close.go
+++ b/close.go
@@ -9,6 +9,8 @@ import (
 
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const closeTimeout = 30 * time.Second
@@ -38,7 +40,7 @@ func dropDatabaseWithRetry(ctx context.Context, dbCli *database.DatabaseAdminCli
 		if lockErr != nil {
 			lastErr = lockErr
 		}
-		if lastErr == nil {
+		if dropDatabaseComplete(lastErr) {
 			return nil
 		}
 		if attempt == dropDatabaseMaxAttempts {
@@ -51,6 +53,10 @@ func dropDatabaseWithRetry(ctx context.Context, dbCli *database.DatabaseAdminCli
 		}
 	}
 	return fmt.Errorf("drop database %s after %d attempts: %w", dbPath, dropDatabaseMaxAttempts, lastErr)
+}
+
+func dropDatabaseComplete(err error) bool {
+	return err == nil || status.Code(err) == codes.NotFound
 }
 
 type closeState struct {

--- a/close.go
+++ b/close.go
@@ -46,10 +46,17 @@ func dropDatabaseWithRetry(ctx context.Context, dbCli *database.DatabaseAdminCli
 		if attempt == dropDatabaseMaxAttempts {
 			break
 		}
+		timer := time.NewTimer(time.Duration(attempt) * 5 * time.Second)
 		select {
 		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
 			return errors.Join(fmt.Errorf("drop database %s: %w", dbPath, lastErr), ctx.Err())
-		case <-time.After(time.Duration(attempt) * 5 * time.Second):
+		case <-timer.C:
 		}
 	}
 	return fmt.Errorf("drop database %s after %d attempts: %w", dbPath, dropDatabaseMaxAttempts, lastErr)

--- a/cmd/spanemuboost/main.go
+++ b/cmd/spanemuboost/main.go
@@ -57,11 +57,12 @@ func usage() {
 	fmt.Fprintf(os.Stderr, `spanemuboost manages long-lived Spanner test backends.
 
 Usage:
-  spanemuboost serve <emulator|omni> --endpoint-file path [--pid-file path]
+  spanemuboost serve <emulator|omni> --endpoint-file path [--pid-file path] [--with-default-database]
   spanemuboost stop --endpoint-file path [--pid-file path]
 
 Examples:
   spanemuboost serve omni --endpoint-file /tmp/omni-endpoint.json
+  spanemuboost serve omni --endpoint-file /tmp/omni-endpoint.json --with-default-database
   spanemuboost stop --endpoint-file /tmp/omni-endpoint.json
   SPANEMUBOOST_ENDPOINT_FILE=/tmp/omni-endpoint.json go test ./...
 

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -97,6 +97,26 @@ func TestParseServeArgs(t *testing.T) {
 	if cfg.Backend != BackendOmni || cfg.EndpointFile != "/tmp/omni.json" {
 		t.Fatalf("ParseServeArgs() = %#v, want omni + /tmp/omni.json", cfg)
 	}
+	if len(cfg.Options) != 1 {
+		t.Fatalf("ParseServeArgs() Options len = %d, want 1 (DisableAutoConfig)", len(cfg.Options))
+	}
+	opts, err := applyOmniOptions(cfg.Options...)
+	if err != nil {
+		t.Fatalf("applyOmniOptions() error = %v", err)
+	}
+	if !opts.disableCreateDatabase || !opts.disableCreateInstance {
+		t.Fatalf("applyOmniOptions() = %#v, want auto-config disabled", opts)
+	}
+}
+
+func TestParseServeArgsOmniWithDefaultDatabase(t *testing.T) {
+	cfg, err := ParseServeArgs([]string{"omni", "--endpoint-file", "/tmp/omni.json", "--with-default-database"})
+	if err != nil {
+		t.Fatalf("ParseServeArgs() error = %v", err)
+	}
+	if len(cfg.Options) != 0 {
+		t.Fatalf("ParseServeArgs() Options len = %d, want 0", len(cfg.Options))
+	}
 }
 
 func TestLoadEndpointMissingEnvMentionsEmulatorURI(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/gcloud v0.42.0
+	golang.org/x/sync v0.21.0
 	google.golang.org/api v0.232.0
 	google.golang.org/grpc v1.79.3
 )
@@ -87,7 +88,6 @@ require (
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/time v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1197,8 +1197,8 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
-golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal.go
+++ b/internal.go
@@ -347,19 +347,14 @@ func bootstrapAndCreateClients(ctx context.Context, emu *Emulator, opts *emulato
 }
 
 func bootstrapAndCreateClientsWithOptions(ctx context.Context, uri string, opts *emulatorOptions, clientOpts []option.ClientOption) (_ *Clients, retErr error) {
-	var instanceCli *instance.InstanceAdminClient
-	if !opts.disableCreateInstance {
-		var err error
-		instanceCli, err = instance.NewInstanceAdminClient(ctx, clientOpts...)
-		if err != nil {
-			return nil, err
-		}
+	instanceCli, err := instance.NewInstanceAdminClient(ctx, clientOpts...)
+	if err != nil {
+		return nil, err
 	}
 	var (
 		dbCli            *database.DatabaseAdminClient
 		client           *spanner.Client
 		createdResources createdSchemaResources
-		err              error
 	)
 	defer func() {
 		if retErr != nil {
@@ -372,9 +367,7 @@ func bootstrapAndCreateClientsWithOptions(ctx context.Context, uri string, opts 
 			if dbCli != nil {
 				logCloseError("close database admin client", dbCli.Close())
 			}
-			if instanceCli != nil {
-				logCloseError("close instance admin client", instanceCli.Close())
-			}
+			logCloseError("close instance admin client", instanceCli.Close())
 		}
 	}()
 

--- a/internal.go
+++ b/internal.go
@@ -180,12 +180,10 @@ func bootstrapInstance(ctx context.Context, opts *emulatorOptions, instanceCli *
 }
 
 // bootstrapDatabase creates the database (with DDLs) or applies DDLs to an existing database.
+// It reports whether this call created the database.
 func bootstrapDatabase(ctx context.Context, opts *emulatorOptions, dbCli *database.DatabaseAdminClient) (bool, error) {
 	if !opts.disableCreateDatabase {
-		if err := createDatabase(ctx, opts, dbCli); err != nil {
-			return false, err
-		}
-		return true, nil
+		return createDatabase(ctx, opts, dbCli)
 	}
 	if len(opts.setupDDLs) > 0 {
 		return false, updateDDLs(ctx, opts, dbCli)
@@ -281,7 +279,7 @@ func bootstrapWithManagedClientConfig(ctx context.Context, opts *emulatorOptions
 	return executeDMLsWithClient(ctx, opts, client)
 }
 
-func createDatabase(ctx context.Context, opts *emulatorOptions, dbCli *database.DatabaseAdminClient) error {
+func createDatabase(ctx context.Context, opts *emulatorOptions, dbCli *database.DatabaseAdminClient) (bool, error) {
 	var createStmt string
 	if opts.databaseDialect != databasepb.DatabaseDialect_POSTGRESQL {
 		createStmt = fmt.Sprintf("CREATE DATABASE `%v`", opts.databaseID)
@@ -303,18 +301,15 @@ func createDatabase(ctx context.Context, opts *emulatorOptions, dbCli *database.
 		}
 		_, err = createDBOp.Wait(ctx)
 	}); lockErr != nil {
-		return lockErr
+		return false, lockErr
 	}
 	if err != nil {
 		if status.Code(err) == codes.AlreadyExists {
-			if len(opts.setupDDLs) > 0 {
-				return updateDDLs(ctx, opts, dbCli)
-			}
-			return nil
+			return false, nil
 		}
-		return err
+		return false, err
 	}
-	return nil
+	return true, nil
 }
 
 func createInstance(ctx context.Context, opts *emulatorOptions, instanceCli *instance.InstanceAdminClient) error {
@@ -406,8 +401,8 @@ func bootstrapAndCreateClientsWithOptions(ctx context.Context, uri string, opts 
 		DatabaseID:     opts.databaseID,
 		clientOpts:     clientOpts,
 		uri:            uri,
-		dropDatabase:   opts.shouldDropDatabase(),
-		dropInstance:   opts.shouldDropInstance(),
+		dropDatabase:   createdResources.database && opts.shouldDropDatabase(),
+		dropInstance:   createdResources.instance && opts.shouldDropInstance(),
 	}, nil
 }
 

--- a/internal.go
+++ b/internal.go
@@ -290,7 +290,7 @@ func createDatabase(ctx context.Context, opts *emulatorOptions, dbCli *database.
 	}
 	instancePath := opts.InstancePath()
 	var err error
-	withInstanceAdminLock(instancePath, func() {
+	if lockErr := withInstanceAdminLock(ctx, instancePath, func() {
 		createDBOp, createErr := dbCli.CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
 			Parent:          instancePath,
 			CreateStatement: createStmt,
@@ -302,7 +302,9 @@ func createDatabase(ctx context.Context, opts *emulatorOptions, dbCli *database.
 			return
 		}
 		_, err = createDBOp.Wait(ctx)
-	})
+	}); lockErr != nil {
+		return lockErr
+	}
 	if err != nil {
 		if status.Code(err) == codes.AlreadyExists {
 			if len(opts.setupDDLs) > 0 {

--- a/internal.go
+++ b/internal.go
@@ -288,18 +288,28 @@ func createDatabase(ctx context.Context, opts *emulatorOptions, dbCli *database.
 	} else {
 		createStmt = fmt.Sprintf(`CREATE DATABASE "%s"`, strings.ReplaceAll(opts.databaseID, `"`, `""`))
 	}
-	createDBOp, err := dbCli.CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
-		Parent:          opts.InstancePath(),
-		CreateStatement: createStmt,
-		DatabaseDialect: opts.databaseDialect,
-		ExtraStatements: opts.setupDDLs,
+	instancePath := opts.InstancePath()
+	var err error
+	withInstanceAdminLock(instancePath, func() {
+		createDBOp, createErr := dbCli.CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
+			Parent:          instancePath,
+			CreateStatement: createStmt,
+			DatabaseDialect: opts.databaseDialect,
+			ExtraStatements: opts.setupDDLs,
+		})
+		if createErr != nil {
+			err = createErr
+			return
+		}
+		_, err = createDBOp.Wait(ctx)
 	})
 	if err != nil {
-		return err
-	}
-
-	_, err = createDBOp.Wait(ctx)
-	if err != nil {
+		if status.Code(err) == codes.AlreadyExists {
+			if len(opts.setupDDLs) > 0 {
+				return updateDDLs(ctx, opts, dbCli)
+			}
+			return nil
+		}
 		return err
 	}
 	return nil
@@ -335,14 +345,19 @@ func bootstrapAndCreateClients(ctx context.Context, emu *Emulator, opts *emulato
 }
 
 func bootstrapAndCreateClientsWithOptions(ctx context.Context, uri string, opts *emulatorOptions, clientOpts []option.ClientOption) (_ *Clients, retErr error) {
-	instanceCli, err := instance.NewInstanceAdminClient(ctx, clientOpts...)
-	if err != nil {
-		return nil, err
+	var instanceCli *instance.InstanceAdminClient
+	if !opts.disableCreateInstance {
+		var err error
+		instanceCli, err = instance.NewInstanceAdminClient(ctx, clientOpts...)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var (
 		dbCli            *database.DatabaseAdminClient
 		client           *spanner.Client
 		createdResources createdSchemaResources
+		err              error
 	)
 	defer func() {
 		if retErr != nil {
@@ -355,7 +370,9 @@ func bootstrapAndCreateClientsWithOptions(ctx context.Context, uri string, opts 
 			if dbCli != nil {
 				logCloseError("close database admin client", dbCli.Close())
 			}
-			logCloseError("close instance admin client", instanceCli.Close())
+			if instanceCli != nil {
+				logCloseError("close instance admin client", instanceCli.Close())
+			}
 		}
 	}()
 
@@ -431,11 +448,8 @@ func rollbackCreatedResources(instanceCli *instance.InstanceAdminClient, dbCli *
 		if dropDatabase {
 			if dbCli == nil {
 				errs = append(errs, fmt.Errorf("rollback drop database %s: database admin client is nil", opts.DatabasePath()))
-			} else {
-				err := dbCli.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: opts.DatabasePath()})
-				if err != nil {
-					errs = append(errs, fmt.Errorf("rollback drop database %s: %w", opts.DatabasePath(), err))
-				}
+			} else if err := dropDatabaseWithRetry(ctx, dbCli, opts.DatabasePath()); err != nil {
+				errs = append(errs, fmt.Errorf("rollback %w", err))
 			}
 		}
 		return errors.Join(errs...)
@@ -446,9 +460,8 @@ func rollbackCreatedResources(instanceCli *instance.InstanceAdminClient, dbCli *
 			errs = append(errs, fmt.Errorf("rollback drop database %s: database admin client is nil", opts.DatabasePath()))
 			return errors.Join(errs...)
 		}
-		err := dbCli.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: opts.DatabasePath()})
-		if err != nil {
-			errs = append(errs, fmt.Errorf("rollback drop database %s: %w", opts.DatabasePath(), err))
+		if err := dropDatabaseWithRetry(ctx, dbCli, opts.DatabasePath()); err != nil {
+			errs = append(errs, fmt.Errorf("rollback %w", err))
 		}
 	}
 	return errors.Join(errs...)

--- a/internal.go
+++ b/internal.go
@@ -392,6 +392,7 @@ func bootstrapAndCreateClientsWithOptions(ctx context.Context, uri string, opts 
 		}
 	}
 
+	forceTeardown := opts.schemaTeardown != nil && *opts.schemaTeardown
 	return &Clients{
 		InstanceClient: instanceCli,
 		DatabaseClient: dbCli,
@@ -401,8 +402,8 @@ func bootstrapAndCreateClientsWithOptions(ctx context.Context, uri string, opts 
 		DatabaseID:     opts.databaseID,
 		clientOpts:     clientOpts,
 		uri:            uri,
-		dropDatabase:   createdResources.database && opts.shouldDropDatabase(),
-		dropInstance:   createdResources.instance && opts.shouldDropInstance(),
+		dropDatabase:   opts.shouldDropDatabase() && (createdResources.database || forceTeardown),
+		dropInstance:   opts.shouldDropInstance() && (createdResources.instance || forceTeardown),
 	}, nil
 }
 

--- a/serve.go
+++ b/serve.go
@@ -71,10 +71,11 @@ func ServeFromConfig(ctx context.Context, cfg ServeConfig) error {
 	return Serve(ctx, cfg.Backend, cfg.EndpointFile, cfg.Options...)
 }
 
-// ParseServeArgs parses `spanemuboost serve <emulator|omni> --endpoint-file path [--pid-file path]`.
+// ParseServeArgs parses `spanemuboost serve <emulator|omni> --endpoint-file path [--pid-file path] [--with-default-database]`.
 func ParseServeArgs(args []string) (ServeConfig, error) {
 	cfg := ServeConfig{}
 	var backend string
+	withDefaultDatabase := false
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--endpoint-file", "-o":
@@ -89,6 +90,8 @@ func ParseServeArgs(args []string) (ServeConfig, error) {
 			}
 			cfg.PIDFile = args[i+1]
 			i++
+		case "--with-default-database":
+			withDefaultDatabase = true
 		case "emulator", "omni":
 			if backend != "" {
 				return ServeConfig{}, fmt.Errorf("multiple backends specified: %q and %q", backend, args[i])
@@ -99,13 +102,16 @@ func ParseServeArgs(args []string) (ServeConfig, error) {
 		}
 	}
 	if backend == "" {
-		return ServeConfig{}, fmt.Errorf("usage: spanemuboost serve <emulator|omni> --endpoint-file path [--pid-file path]")
+		return ServeConfig{}, fmt.Errorf("usage: spanemuboost serve <emulator|omni> --endpoint-file path [--pid-file path] [--with-default-database]")
 	}
 	switch Backend(backend) {
 	case BackendEmulator:
 		cfg.Backend = BackendEmulator
 	case BackendOmni:
 		cfg.Backend = BackendOmni
+		if !withDefaultDatabase {
+			cfg.Options = append(cfg.Options, DisableAutoConfig())
+		}
 	default:
 		return ServeConfig{}, fmt.Errorf("unsupported serve backend %q; supported values are emulator and omni", backend)
 	}

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -8,7 +8,6 @@ import (
 
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
-	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
 	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
 	tcspanner "github.com/testcontainers/testcontainers-go/modules/gcloud/spanner"
@@ -104,10 +103,8 @@ func (c *Clients) Close() error {
 			} else if c.dropDatabase {
 				if c.DatabaseClient == nil {
 					errs = append(errs, fmt.Errorf("drop database %s: database admin client is nil", c.DatabasePath()))
-				} else if err := c.DatabaseClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
-					Database: c.DatabasePath(),
-				}); err != nil {
-					errs = append(errs, fmt.Errorf("drop database %s: %w", c.DatabasePath(), err))
+				} else if err := dropDatabaseWithRetry(ctx, c.DatabaseClient, c.DatabasePath()); err != nil {
+					errs = append(errs, err)
 				}
 			}
 		}

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -87,26 +87,26 @@ func (c *Clients) Close() error {
 			c.Client.Close()
 		}
 
-		if c.dropInstance || c.dropDatabase {
+		if c.dropInstance {
 			ctx, cancel := newCloseContext()
-			defer cancel()
-			if c.dropInstance {
-				// Deleting the instance also removes all databases within it,
-				// so there is no need to drop the database separately.
-				if c.InstanceClient == nil {
-					errs = append(errs, fmt.Errorf("delete instance %s: instance admin client is nil", c.InstancePath()))
-				} else if err := c.InstanceClient.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{
-					Name: c.InstancePath(),
-				}); err != nil {
-					errs = append(errs, fmt.Errorf("delete instance %s: %w", c.InstancePath(), err))
-				}
-			} else if c.dropDatabase {
-				if c.DatabaseClient == nil {
-					errs = append(errs, fmt.Errorf("drop database %s: database admin client is nil", c.DatabasePath()))
-				} else if err := dropDatabaseWithRetry(ctx, c.DatabaseClient, c.DatabasePath()); err != nil {
-					errs = append(errs, err)
-				}
+			// Deleting the instance also removes all databases within it,
+			// so there is no need to drop the database separately.
+			if c.InstanceClient == nil {
+				errs = append(errs, fmt.Errorf("delete instance %s: instance admin client is nil", c.InstancePath()))
+			} else if err := c.InstanceClient.DeleteInstance(ctx, &instancepb.DeleteInstanceRequest{
+				Name: c.InstancePath(),
+			}); err != nil {
+				errs = append(errs, fmt.Errorf("delete instance %s: %w", c.InstancePath(), err))
 			}
+			cancel()
+		} else if c.dropDatabase {
+			ctx, cancel := newDropDatabaseContext()
+			if c.DatabaseClient == nil {
+				errs = append(errs, fmt.Errorf("drop database %s: database admin client is nil", c.DatabasePath()))
+			} else if err := dropDatabaseWithRetry(ctx, c.DatabaseClient, c.DatabasePath()); err != nil {
+				errs = append(errs, err)
+			}
+			cancel()
 		}
 
 		if c.DatabaseClient != nil {

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -8,11 +8,14 @@ import (
 	"testing"
 
 	"cloud.google.com/go/spanner"
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/google/go-cmp/cmp"
 	dcontainer "github.com/moby/moby/api/types/container"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type closeCountingRuntime struct {
@@ -620,6 +623,31 @@ func TestSchemaTeardown(t *testing.T) {
 		}
 		if err := reconnectClients.Close(); err != nil {
 			t.Errorf("failed to close reconnect clients: %v", err)
+		}
+
+		forceClients, err := OpenClients(t.Context(), emu,
+			WithDatabaseID("skip-teardown"),
+			ForceSchemaTeardown(),
+		)
+		if err != nil {
+			t.Fatalf("OpenClients() with ForceSchemaTeardown error = %v, want nil", err)
+		}
+		forceDatabasePath := forceClients.DatabasePath()
+		if err := forceClients.Close(); err != nil {
+			t.Errorf("failed to close forced teardown clients: %v", err)
+		}
+
+		dbCli, err := database.NewDatabaseAdminClient(t.Context(), emu.ClientOptions()...)
+		if err != nil {
+			t.Fatalf("NewDatabaseAdminClient() error = %v", err)
+		}
+		defer func() {
+			if err := dbCli.Close(); err != nil {
+				t.Errorf("failed to close database admin client: %v", err)
+			}
+		}()
+		if _, err := dbCli.GetDatabase(t.Context(), &databasepb.GetDatabaseRequest{Name: forceDatabasePath}); status.Code(err) != codes.NotFound {
+			t.Fatalf("GetDatabase() after ForceSchemaTeardown error = %v, want NotFound", err)
 		}
 	})
 

--- a/spanemuboost_test.go
+++ b/spanemuboost_test.go
@@ -595,14 +595,31 @@ func TestSchemaTeardown(t *testing.T) {
 			)
 			mustConsumeQuery(t, clients, "SELECT 1")
 		})
-		// Database still exists, so re-creating should fail.
-		// On error OpenClients returns (nil, err), so no Close call is needed.
-		_, err := OpenClients(t.Context(), emu,
+
+		// Database still exists, so auto-create treats AlreadyExists as an
+		// already-bootstrapped database and must not re-apply the same DDLs.
+		clients, err := OpenClients(t.Context(), emu,
 			WithDatabaseID("skip-teardown"),
 			WithSetupDDLs(ddls),
 		)
-		if err == nil {
-			t.Fatal("expected 'already exists' error, but got nil")
+		if err != nil {
+			t.Fatalf("OpenClients() existing database error = %v, want nil", err)
+		}
+		mustConsumeQuery(t, clients, "SELECT COUNT(*) FROM tbl")
+		if err := clients.Close(); err != nil {
+			t.Errorf("failed to close existing database clients: %v", err)
+		}
+
+		// Closing clients that reused the existing database must not drop it.
+		reconnectClients, err := OpenClients(t.Context(), emu,
+			WithDatabaseID("skip-teardown"),
+			DisableAutoConfig(),
+		)
+		if err != nil {
+			t.Fatalf("reconnect existing database error = %v, want nil", err)
+		}
+		if err := reconnectClients.Close(); err != nil {
+			t.Errorf("failed to close reconnect clients: %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Serialize Spanner admin database lifecycle operations per instance so concurrent create/drop LROs do not collide on emulator or Omni admin paths.
- Add retry-backed database drop cleanup with a longer database-specific timeout while keeping instance deletion on the normal close timeout.
- Change `spanemuboost serve omni` to skip default instance/database bootstrap by default; `--with-default-database` preserves the previous eager default-database behavior.
- Keep `Clients.InstanceClient` consistently available even when instance creation is disabled, matching Omni default/default behavior and the public `Clients` shape.
- Treat `CreateDatabase` `AlreadyExists` as reuse of an already-bootstrapped database without re-applying DDLs, while avoiding rollback/Close teardown of reused resources unless `ForceSchemaTeardown()` is explicit.

## What changed
- Added `admin_ops.go` with a per-instance admin lock keyed by instance resource path.
- Wrapped `CreateDatabase` and `DropDatabase` operations with that lock.
- Added `dropDatabaseWithRetry`, `newDropDatabaseContext`, NotFound-as-complete cleanup handling, and timer-safe retry backoff.
- Preserved explicit `ForceSchemaTeardown()` for reused resources and added regression coverage.
- Updated `serve omni` argument parsing, CLI usage, README documentation, and endpoint argument tests for the new default and `--with-default-database` override.
- Promoted `golang.org/x/sync` to a direct dependency for the semaphore used by the admin lock.

## Diff basis
Reviewed with `git diff origin/main` on `codex/reconcile-main-local-commits` at `6fed7ba` after rebasing onto current `origin/main`.

Notable files:
- `admin_ops.go`, `admin_ops_test.go`: per-instance lock and unit coverage.
- `close.go`, `internal.go`, `spanemuboost.go`: database create/drop serialization, retry budget, existing database reuse, and close/rollback integration.
- `serve.go`, `cmd/spanemuboost/main.go`, `README.md`, `endpoint_test.go`: Omni serve default change and CLI/docs coverage.
- `go.mod`, `go.sum`: direct `golang.org/x/sync` dependency.

## Validation
- `git diff --check`
- `go test ./... -run "TestWithInstanceAdminLockCancelsWhileWaiting|TestDropDatabaseRetryBudget|TestDropDatabaseComplete|TestParseServeArgs|TestParseServeArgsOmniWithDefaultDatabase|TestClientsCloseNilSafeAndIdempotent"`
- GitHub checks passed: `build-and-test`, `lint`, `omni-smoke`, `podman-smoke`
- Gemini Code Assist reviewed current HEAD `6fed7ba` with no comments to address