### PR TITLE
Bump runtime container images to emulator 1.5.55 and Omni 2026.r1-beta.2

### DIFF
--- a/docs/omni-runtime-environments.md
+++ b/docs/omni-runtime-environments.md
@@ -207,7 +207,7 @@ Use this to recheck a runtime without running Go tests:
 ```sh
 podman volume create spanner
 podman run -d --network host --name spanneromni -v spanner:/spanner \
-  us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r1-beta.1 \
+  us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r1-beta.2 \
   start-single-server
 podman logs --tail 120 spanneromni
 podman exec spanneromni /google/spanner/bin/spanner databases create-sample-db retail --database-name=retail-sample

--- a/omni.go
+++ b/omni.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	defaultOmniImage      = "us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r1-beta.1"
+	defaultOmniImage      = "us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r1-beta.2"
 	defaultOmniProjectID  = "default"
 	defaultOmniInstanceID = "default"
 )

--- a/spanemuboost.go
+++ b/spanemuboost.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DefaultEmulatorImage = "gcr.io/cloud-spanner-emulator/emulator:1.5.54"
+	DefaultEmulatorImage = "gcr.io/cloud-spanner-emulator/emulator:1.5.55"
 	DefaultProjectID     = "emulator-project"
 	DefaultInstanceID    = "emulator-instance"
 	DefaultDatabaseID    = "emulator-database"


### PR DESCRIPTION
## Summary

- Bump default Cloud Spanner emulator image from `1.5.54` to `1.5.55` (released 2026-06-23 per [GoogleCloudPlatform/cloud-spanner-emulator v1.5.55](https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/releases/tag/v1.5.55)).
- Bump default Spanner Omni image from `2026.r1-beta.1` to `2026.r1-beta.2` per [Spanner Omni download docs](https://docs.cloud.google.com/spanner-omni/download).
- Update the quickstart probe example in `docs/omni-runtime-environments.md`; historical failure notes retain the image tag used at the time.

## Test plan

- [x] `go test -run '^$' ./...`
- [x] `git diff --check`
- [x] CI emulator smoke (default image pull)
- [ ] Optional: `SPANEMUBOOST_ENABLE_OMNI_TESTS=1 make omni-smoke` with new Omni tag


Made with [Cursor](https://cursor.com)