### PR TITLE
Harden Omni startup wait deadline

### DIFF
--- a/omni.go
+++ b/omni.go
@@ -287,7 +287,9 @@ func newOmni(ctx context.Context, opts *emulatorOptions) (testcontainers.Contain
 			WaitingFor: wait.ForAll(
 				wait.ForLog("Spanner is ready").WithStartupTimeout(omniStartupTimeout),
 				wait.ForExposedPort().SkipInternalCheck().WithStartupTimeout(omniStartupTimeout),
-			).WithDeadline(omniStartupTimeout),
+			).
+				WithStartupTimeoutDefault(omniStartupTimeout).
+				WithDeadline(omniStartupTimeout),
 		},
 		Started: true,
 	}

--- a/omni.go
+++ b/omni.go
@@ -23,6 +23,7 @@ const (
 	defaultOmniImage      = "us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r1-beta.2"
 	defaultOmniProjectID  = "default"
 	defaultOmniInstanceID = "default"
+	omniStartupTimeout    = 5 * time.Minute
 )
 
 var omniGRPCPort = nat.Port("15000/tcp")
@@ -284,9 +285,9 @@ func newOmni(ctx context.Context, opts *emulatorOptions) (testcontainers.Contain
 			ExposedPorts: []string{string(omniGRPCPort)},
 			Cmd:          []string{"start-single-server"},
 			WaitingFor: wait.ForAll(
-				wait.ForLog("Spanner is ready"),
-				wait.ForExposedPort().SkipInternalCheck(),
-			).WithDeadline(5 * time.Minute),
+				wait.ForLog("Spanner is ready").WithStartupTimeout(omniStartupTimeout),
+				wait.ForExposedPort().SkipInternalCheck().WithStartupTimeout(omniStartupTimeout),
+			).WithDeadline(omniStartupTimeout),
 		},
 		Started: true,
 	}

--- a/omni_test.go
+++ b/omni_test.go
@@ -14,12 +14,6 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-type containerCustomizerFunc func(*testcontainers.GenericContainerRequest) error
-
-func (f containerCustomizerFunc) Customize(req *testcontainers.GenericContainerRequest) error {
-	return f(req)
-}
-
 func TestRecommendedOmniClientConfig(t *testing.T) {
 	config := RecommendedOmniClientConfig()
 	if !config.DisableNativeMetrics {
@@ -49,7 +43,7 @@ func TestNewOmniConfiguresStartupWaitTimeouts(t *testing.T) {
 	captureErr := errors.New("capture omni request")
 	var req testcontainers.GenericContainerRequest
 
-	opts, err := applyOmniOptions(WithContainerCustomizers(containerCustomizerFunc(func(r *testcontainers.GenericContainerRequest) error {
+	opts, err := applyOmniOptions(WithContainerCustomizers(testcontainers.CustomizeRequestOption(func(r *testcontainers.GenericContainerRequest) error {
 		req = *r
 		return captureErr
 	})))
@@ -57,7 +51,7 @@ func TestNewOmniConfiguresStartupWaitTimeouts(t *testing.T) {
 		t.Fatalf("applyOmniOptions: %v", err)
 	}
 
-	_, err = newOmni(context.Background(), opts)
+	_, err = newOmni(t.Context(), opts)
 	if !errors.Is(err, captureErr) {
 		t.Fatalf("newOmni() error = %v, want %v", err, captureErr)
 	}

--- a/omni_test.go
+++ b/omni_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -70,7 +69,7 @@ func TestNewOmniConfiguresStartupWaitTimeouts(t *testing.T) {
 	if !ok {
 		t.Fatalf("WaitingFor = %T, want *wait.MultiStrategy", req.WaitingFor)
 	}
-	assertWaitDeadline(t, multiStrategy, omniStartupTimeout)
+	assertWaitTimeout(t, "combined", multiStrategy.Timeout(), omniStartupTimeout)
 
 	var sawLogWait, sawPortWait bool
 	root := req.WaitingFor
@@ -92,21 +91,6 @@ func TestNewOmniConfiguresStartupWaitTimeouts(t *testing.T) {
 	}
 	if !sawPortWait {
 		t.Fatal("exposed-port wait strategy not found")
-	}
-}
-
-func assertWaitDeadline(t *testing.T, strategy *wait.MultiStrategy, want time.Duration) {
-	t.Helper()
-
-	deadline := reflect.ValueOf(strategy).Elem().FieldByName("deadline")
-	if !deadline.IsValid() {
-		t.Fatal("combined deadline field not found")
-	}
-	if deadline.IsNil() {
-		t.Fatalf("combined deadline = nil, want %s", want)
-	}
-	if got := time.Duration(deadline.Elem().Int()); got != want {
-		t.Fatalf("combined deadline = %s, want %s", got, want)
 	}
 }
 

--- a/omni_test.go
+++ b/omni_test.go
@@ -2,13 +2,24 @@ package spanemuboost
 
 import (
 	"context"
+	"errors"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
+
+type containerCustomizerFunc func(*testcontainers.GenericContainerRequest) error
+
+func (f containerCustomizerFunc) Customize(req *testcontainers.GenericContainerRequest) error {
+	return f(req)
+}
 
 func TestRecommendedOmniClientConfig(t *testing.T) {
 	config := RecommendedOmniClientConfig()
@@ -32,6 +43,81 @@ func TestOmniRuntimeCloseZeroValue(t *testing.T) {
 	}
 	if err := runtime.Close(); err != nil {
 		t.Fatalf("second Close() error = %v, want nil", err)
+	}
+}
+
+func TestNewOmniConfiguresStartupWaitTimeouts(t *testing.T) {
+	captureErr := errors.New("capture omni request")
+	var req testcontainers.GenericContainerRequest
+
+	opts, err := applyOmniOptions(WithContainerCustomizers(containerCustomizerFunc(func(r *testcontainers.GenericContainerRequest) error {
+		req = *r
+		return captureErr
+	})))
+	if err != nil {
+		t.Fatalf("applyOmniOptions: %v", err)
+	}
+
+	_, err = newOmni(context.Background(), opts)
+	if !errors.Is(err, captureErr) {
+		t.Fatalf("newOmni() error = %v, want %v", err, captureErr)
+	}
+	if req.WaitingFor == nil {
+		t.Fatal("WaitingFor is nil")
+	}
+
+	multiStrategy, ok := req.WaitingFor.(*wait.MultiStrategy)
+	if !ok {
+		t.Fatalf("WaitingFor = %T, want *wait.MultiStrategy", req.WaitingFor)
+	}
+	assertWaitDeadline(t, multiStrategy, omniStartupTimeout)
+
+	var sawLogWait, sawPortWait bool
+	root := req.WaitingFor
+	if err := wait.Walk(&root, func(strategy wait.Strategy) error {
+		switch strategy := strategy.(type) {
+		case *wait.LogStrategy:
+			sawLogWait = true
+			assertWaitTimeout(t, "log", strategy.Timeout(), omniStartupTimeout)
+		case *wait.HostPortStrategy:
+			sawPortWait = true
+			assertWaitTimeout(t, "exposed-port", strategy.Timeout(), omniStartupTimeout)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk wait strategies: %v", err)
+	}
+	if !sawLogWait {
+		t.Fatal("log wait strategy not found")
+	}
+	if !sawPortWait {
+		t.Fatal("exposed-port wait strategy not found")
+	}
+}
+
+func assertWaitDeadline(t *testing.T, strategy *wait.MultiStrategy, want time.Duration) {
+	t.Helper()
+
+	deadline := reflect.ValueOf(strategy).Elem().FieldByName("deadline")
+	if !deadline.IsValid() {
+		t.Fatal("combined deadline field not found")
+	}
+	if deadline.IsNil() {
+		t.Fatalf("combined deadline = nil, want %s", want)
+	}
+	if got := time.Duration(deadline.Elem().Int()); got != want {
+		t.Fatalf("combined deadline = %s, want %s", got, want)
+	}
+}
+
+func assertWaitTimeout(t *testing.T, name string, got *time.Duration, want time.Duration) {
+	t.Helper()
+
+	if got == nil {
+		t.Fatalf("%s timeout = nil, want %s", name, want)
+	}
+	if *got != want {
+		t.Fatalf("%s timeout = %s, want %s", name, *got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Apply the shared `omniStartupTimeout` to the Omni log wait, exposed-port wait, and combined wait deadline.
- Add a focused no-Docker unit test that captures the Omni container request and verifies the configured wait deadlines.

## Test plan
- `go test ./... -run TestNewOmniConfiguresStartupWaitTimeouts`
- `go test ./...`
- `git diff --check`

`SPANEMUBOOST_ENABLE_OMNI_TESTS` was not set, so opt-in Docker/Omni integration tests were not run.

Made with [Cursor](https://cursor.com)