### PR TITLE
Clarify lazy runtime Close concurrency semantics

### DIFF
--- a/emulator.go
+++ b/emulator.go
@@ -105,6 +105,14 @@ func (e *Emulator) runtimePlatform(ctx context.Context) (string, error) {
 // Use [NewLazyEmulator] in a package-level var, then pass directly to [SetupClients]
 // or [OpenClients]. Call [LazyEmulator.Setup] or [LazyEmulator.Get] for standalone access.
 // [LazyEmulator.Close] is safe to call even if the emulator was never started (no-op).
+//
+// Concurrent first use and cleanup are serialized. If [LazyEmulator.Get] or
+// [LazyEmulator.Setup] starts initialization before [LazyEmulator.Close], Close
+// waits for initialization to finish and then closes the started emulator; that
+// concurrent first-use call may still return the emulator that Close is closing
+// or has closed. If Close runs before initialization starts, the emulator is
+// never started and later first-use calls fail. Callers should coordinate so
+// returned emulators are not used after Close begins.
 type LazyEmulator struct {
 	state lazyRuntimeState
 	opts  []Option
@@ -127,7 +135,8 @@ func (le *LazyEmulator) get(ctx context.Context) (runtimeInstance, error) {
 }
 
 // Get starts the emulator on first call (thread-safe via [sync.Once]) and
-// returns the cached [*Emulator] on subsequent calls.
+// returns the cached [*Emulator] on subsequent calls. It may run concurrently
+// with [LazyEmulator.Close]; see [LazyEmulator] for the lifecycle invariant.
 func (le *LazyEmulator) Get(ctx context.Context) (*Emulator, error) {
 	runtime, err := le.get(ctx)
 	if err != nil {
@@ -144,6 +153,9 @@ func (le *LazyEmulator) Get(ctx context.Context) (*Emulator, error) {
 // Close is nil-safe and idempotent — subsequent calls return the result of the first call.
 // Close waits for any in-progress initialization to complete before checking.
 // If Close is called before any Get or Setup, the emulator will never be started.
+// If the first Get or Setup is already initializing, Close closes the emulator
+// after initialization finishes; that concurrent first-use call may still
+// return the emulator.
 func (le *LazyEmulator) Close() error {
 	if le == nil {
 		return nil

--- a/lazy.go
+++ b/lazy.go
@@ -62,6 +62,14 @@ func (s *lazyRuntimeState) close() error {
 // for standalone access, and pair it with [LazyRuntime.Close] or [LazyRuntime.TestMain]
 // when you need the lazy handle to own lifecycle cleanup. [LazyRuntime.Close] is
 // safe to call even if the runtime was never started (no-op).
+//
+// Concurrent first use and cleanup are serialized. If [LazyRuntime.Get] or
+// [LazyRuntime.Setup] starts initialization before [LazyRuntime.Close], Close
+// waits for initialization to finish and then closes the started runtime; that
+// concurrent first-use call may still return the runtime that Close is closing
+// or has closed. If Close runs before initialization starts, the runtime is
+// never started and later first-use calls fail. Callers should coordinate so
+// returned runtimes are not used after Close begins.
 type LazyRuntime struct {
 	state   lazyRuntimeState
 	backend Backend
@@ -99,7 +107,8 @@ func (lr *LazyRuntime) get(ctx context.Context) (runtimeInstance, error) {
 }
 
 // Get starts the selected backend on first call (thread-safe via [sync.Once])
-// and returns the cached [Runtime] on subsequent calls.
+// and returns the cached [Runtime] on subsequent calls. It may run concurrently
+// with [LazyRuntime.Close]; see [LazyRuntime] for the lifecycle invariant.
 func (lr *LazyRuntime) Get(ctx context.Context) (Runtime, error) {
 	runtime, err := lr.get(ctx)
 	if err != nil {
@@ -112,6 +121,9 @@ func (lr *LazyRuntime) Get(ctx context.Context) (Runtime, error) {
 // Close is nil-safe and idempotent — subsequent calls return the result of the first call.
 // Close waits for any in-progress initialization to complete before checking.
 // If Close is called before any Get or Setup, the runtime will never be started.
+// If the first Get or Setup is already initializing, Close closes the runtime
+// after initialization finishes; that concurrent first-use call may still
+// return the runtime.
 func (lr *LazyRuntime) Close() error {
 	if lr == nil {
 		return nil

--- a/lazy_test.go
+++ b/lazy_test.go
@@ -2,7 +2,10 @@ package spanemuboost
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+
+	"google.golang.org/api/option"
 )
 
 func TestLazyEmulatorCloseAfterFailedGet(t *testing.T) {
@@ -54,6 +57,35 @@ func TestLazyRuntimeStateGetRepanicsAfterStartPanic(t *testing.T) {
 	assertPanic(2)
 }
 
+func TestLazyRuntimeStateCloseAfterStartPanic(t *testing.T) {
+	var state lazyRuntimeState
+	const want = "boom"
+
+	assertPanic := func(call string, start func(context.Context) (runtimeInstance, error)) {
+		t.Helper()
+
+		defer func() {
+			if got := recover(); got != want {
+				t.Fatalf("%s: panic = %v, want %q", call, got, want)
+			}
+		}()
+
+		_, _ = state.get(t.Context(), start, "unused")
+		t.Fatalf("%s: get() returned normally, want panic", call)
+	}
+
+	assertPanic("first get", func(context.Context) (runtimeInstance, error) {
+		panic(want)
+	})
+	if err := state.close(); err != nil {
+		t.Fatalf("Close() after panicking Get() error = %v, want nil", err)
+	}
+	assertPanic("second get", func(context.Context) (runtimeInstance, error) {
+		t.Fatal("start function called after initial panic")
+		return nil, nil
+	})
+}
+
 func TestLazyRuntimeStateGetRepanicsAfterNilPanic(t *testing.T) {
 	var state lazyRuntimeState
 
@@ -76,4 +108,128 @@ func TestLazyRuntimeStateGetRepanicsAfterNilPanic(t *testing.T) {
 
 	assertPanics(1)
 	assertPanics(2)
+}
+
+func TestLazyRuntimeStateCloseBeforeGetPreventsStart(t *testing.T) {
+	var state lazyRuntimeState
+	var starts atomic.Int32
+
+	if err := state.close(); err != nil {
+		t.Fatalf("Close() error = %v, want nil", err)
+	}
+
+	runtime, err := state.get(t.Context(), func(context.Context) (runtimeInstance, error) {
+		starts.Add(1)
+		return &fakeRuntimeInstance{}, nil
+	}, "closed before start")
+	if err == nil {
+		t.Fatal("get() error = nil, want non-nil")
+	}
+	if got := err.Error(); got != "closed before start" {
+		t.Fatalf("get() error = %q, want %q", got, "closed before start")
+	}
+	if runtime != nil {
+		t.Fatalf("get() runtime = %T, want nil", runtime)
+	}
+	if got := starts.Load(); got != 0 {
+		t.Fatalf("start calls = %d, want 0", got)
+	}
+}
+
+func TestLazyRuntimeStateConcurrentGetAndCloseGetWins(t *testing.T) {
+	var state lazyRuntimeState
+	runtime := &fakeRuntimeInstance{}
+	started := make(chan struct{})
+	releaseStart := make(chan struct{})
+
+	defer func() {
+		select {
+		case <-releaseStart:
+		default:
+			close(releaseStart)
+		}
+	}()
+
+	type getResult struct {
+		runtime runtimeInstance
+		err     error
+	}
+	ctx := t.Context()
+	getDone := make(chan getResult, 1)
+	go func() {
+		got, err := state.get(ctx, func(context.Context) (runtimeInstance, error) {
+			close(started)
+			<-releaseStart
+			return runtime, nil
+		}, "unused")
+		getDone <- getResult{runtime: got, err: err}
+	}()
+
+	<-started
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- state.close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close() returned before in-progress Get() finished: %v", err)
+	default:
+	}
+
+	close(releaseStart)
+
+	result := <-getDone
+	if result.err != nil {
+		t.Fatalf("get() error = %v, want nil", result.err)
+	}
+	if result.runtime != runtime {
+		t.Fatalf("get() runtime = %T, want %T", result.runtime, runtime)
+	}
+	if err := <-closeDone; err != nil {
+		t.Fatalf("Close() error = %v, want nil", err)
+	}
+	if got := runtime.closeCalls.Load(); got != 1 {
+		t.Fatalf("runtime Close() calls = %d, want 1", got)
+	}
+}
+
+type fakeRuntimeInstance struct {
+	closeCalls atomic.Int32
+}
+
+func (*fakeRuntimeInstance) spanemuboostRuntime() {}
+
+func (*fakeRuntimeInstance) URI() string { return "localhost:9010" }
+
+func (*fakeRuntimeInstance) ClientOptions() []option.ClientOption { return nil }
+
+func (r *fakeRuntimeInstance) Close() error {
+	r.closeCalls.Add(1)
+	return nil
+}
+
+func (*fakeRuntimeInstance) ProjectID() string { return "project" }
+
+func (*fakeRuntimeInstance) InstanceID() string { return "instance" }
+
+func (*fakeRuntimeInstance) DatabaseID() string { return "database" }
+
+func (*fakeRuntimeInstance) ProjectPath() string { return "projects/project" }
+
+func (*fakeRuntimeInstance) InstancePath() string {
+	return "projects/project/instances/instance"
+}
+
+func (*fakeRuntimeInstance) DatabasePath() string {
+	return "projects/project/instances/instance/databases/database"
+}
+
+func (*fakeRuntimeInstance) inheritedOptions(...Option) (*emulatorOptions, error) {
+	return &emulatorOptions{}, nil
+}
+
+func (*fakeRuntimeInstance) runtimePlatform(context.Context) (string, error) {
+	return "fake", nil
 }

--- a/testing.go
+++ b/testing.go
@@ -88,6 +88,8 @@ func setupLazy[T any](tb testing.TB, get func(context.Context) (T, error)) T {
 
 // Setup starts the selected backend on first call (thread-safe via [sync.Once])
 // and returns the cached [Runtime] on subsequent calls.
+// It may run concurrently with [LazyRuntime.Close]; see [LazyRuntime] for the
+// lifecycle invariant.
 // It calls [testing.TB.Fatal] if startup fails.
 // For use with [SetupClients] or [OpenClients], you can pass [*LazyRuntime] directly
 // without calling Setup.
@@ -97,6 +99,8 @@ func (lr *LazyRuntime) Setup(tb testing.TB) Runtime {
 
 // Setup starts the emulator on first call (thread-safe via [sync.Once]) and
 // returns the cached [*Emulator] on subsequent calls.
+// It may run concurrently with [LazyEmulator.Close]; see [LazyEmulator] for the
+// lifecycle invariant.
 // It calls [testing.TB.Fatal] if startup fails.
 // For use with [SetupClients] or [OpenClients], you can pass [*LazyEmulator] directly
 // without calling Setup.


### PR DESCRIPTION
## Summary
- Clarifies the conservative LazyRuntime/LazyEmulator invariant for concurrent first Get/Setup and Close, including the Get-wins and Close-wins outcomes.
- Adds race-detector-friendly lazy state tests for Close-before-start, concurrent Get-and-Close, and Close after startup panic.

Fixes #39.

## Test plan
- `go test -race -run 'TestLazy' ./...`
- `TESTCONTAINERS_RYUK_DISABLED=true go test -race ./...`
- `git diff --check`

Made with [Cursor](https://cursor.com)